### PR TITLE
Update download links to use socrata API instead

### DIFF
--- a/app/components/Dataset/DatasetDownloads.jsx
+++ b/app/components/Dataset/DatasetDownloads.jsx
@@ -1,12 +1,11 @@
 import React, { Component } from 'react'
 import { MenuItem, DropdownButton } from 'react-bootstrap'
 
-const downloadTypes = {
-  'csv': 'CSV',
-  'xls': 'Excel 2003',
-  'xlsx': 'Excel 2007+',
-  'geojson': 'GeoJSON',
-  'json': 'JSON'
+// ToDo: create isGeo property of the dataset, also possibly abstract this out of here to allow different configurable URL patterns (not tied to Socrata)
+let downloadTypes = {
+  'csv': 'CSV (Spreadsheet)',
+  'json': 'JSON',
+  'geojson': 'GeoJSON'
 }
 // should be abstracted more to allow different download template links based or an array of link options, maybe can be loaded as part of middleware?
 class DownloadLinks extends Component {
@@ -19,9 +18,9 @@ class DownloadLinks extends Component {
       id = migrationId
     }
     let menuItems = options.map(function (type, i) {
-      let downloadLink = 'https://' + apiDomain + '/api/views/' + id + '/rows.' + type + '?accessType=DOWNLOAD'
+      let downloadLink = 'https://' + apiDomain + '/resource/' + id + '.' + type + '?$limit=99999999999'
       return (
-        <MenuItem href={downloadLink} key={i} eventKey={i}>
+        <MenuItem href={downloadLink} key={i} eventKey={i} download='Download'>
           {downloadTypes[type]}
         </MenuItem>
       )

--- a/test/components/Dataset/DatasetDownloads.spec.js
+++ b/test/components/Dataset/DatasetDownloads.spec.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import DatasetDownloads from '../../../app/components/Dataset/DatasetDownloads'
+import { Col } from 'react-bootstrap'
+
+describe('<DatasetDownloads />', () => {
+
+  it('Renders 3 download options with valid links', () => {
+    const wrapper = mount(<DatasetDownloads apiDomain='data.sfgov.org' id='4545-4545' migrationId='1212-1212' />)
+    const downloadOpts = wrapper.find('ul.dropdown-menu li a')
+
+    expect(downloadOpts).to.have.length(3)
+
+    const match = /(csv|json|geojson)/
+    downloadOpts.forEach((node) => {
+      expect(node.prop('href')).to.match(match)
+    })
+  })
+
+})

--- a/test/components/Dataset/DatasetFrontMatter.spec.js
+++ b/test/components/Dataset/DatasetFrontMatter.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import DatasetFrontMatter from '../../app/components/Dataset/DatasetFrontMatter'
+import DatasetFrontMatter from '../../../app/components/Dataset/DatasetFrontMatter'
 import { Col } from 'react-bootstrap'
 
 describe('<DatasetFrontMatter/>', () => {


### PR DESCRIPTION
Per #122 modified the download links to grab data from the API /resources endpoint. I'm just including csv, json and geojson for now.  I've dropped Excel downloads as they truncate data anyway and I'd rather not surface them as is.

The DatasetDownloads component will need a little refactoring, but should be easy to implement a conditional check for geo format downloads. I have a related issue here #136 