### PR TITLE
Making home page search minimally viable to avoid user confusion

### DIFF
--- a/app/app.jsx
+++ b/app/app.jsx
@@ -6,9 +6,9 @@ import { hashHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
 import Root from './containers/Root'
 import configureStore from './store/configureStore'
-var airbrakeJs = require('airbrake-js')
-/*ignore jslint start*/
-window.airbrake = new airbrakeJs({projectId: 129534, projectKey: '9a82934389a163571bd7dd056cbfec5d'})  // eslint-disable-line
+import airbrakeJs from 'airbrake-js'
+window.airbrake = new airbrakeJs({projectId: 129600, projectKey: 'b8fe4ddb8be71382afa569e93c9b0d87'}) // eslint-disable-line
+
 const initialState = {
   dataset: {
     query: {
@@ -19,8 +19,6 @@ const initialState = {
     }
   }
 }
-var airbrakeJs = require('airbrake-js')
-window.airbrake = new airbrakeJs({projectId: 129600, projectKey: 'b8fe4ddb8be71382afa569e93c9b0d87'}) // eslint-disable-line
 const store = configureStore(initialState)
 const history = syncHistoryWithStore(hashHistory, store)
 render(

--- a/app/components/App/App.jsx
+++ b/app/components/App/App.jsx
@@ -1,3 +1,4 @@
+import './_App.scss'
 import React from 'react'
 import Navigation from '../Navigation/Navigation'
 import Footer from '../Footer/Footer'
@@ -17,7 +18,9 @@ export default class App extends React.Component {
     return (
       <div className={'app'}>
         <Navigation pages={pages} />
+        <div className={'content-wrapper'}>
           {this.props.children}
+        </div>
         <Footer />
       </div>
     )

--- a/app/components/App/_App.scss
+++ b/app/components/App/_App.scss
@@ -1,3 +1,5 @@
+@import toolkit;
+
 .content-wrapper {
 	margin-top: 100px;
 }

--- a/app/components/Catalog/Catalog.jsx
+++ b/app/components/Catalog/Catalog.jsx
@@ -60,7 +60,6 @@ export default class CatalogBrowse extends React.Component {
     var facets = {}
     facets.departments = content.getFacetValues('publishing_dept')
     facets.categories = content.getFacetValues('category')
-    console.log(facets.departments)
     this.setState({
       results: content.hits,
       facets: facets,
@@ -107,8 +106,10 @@ export default class CatalogBrowse extends React.Component {
       console.error(err)
     })
 
-    helper.setQuery('')
-    .search()
+    let { searchTerm } = this.props
+
+    helper.setQuery(searchTerm)
+      .search()
   }
 
   componentWillUnmount () {
@@ -118,6 +119,7 @@ export default class CatalogBrowse extends React.Component {
 
   render () {
     let { facets } = this.state
+    let { searchTerm } = this.props
     let listItems = []
     if (this.state.results.length > 0) {
       listItems = this.state.results.map(function (dataset, i) {
@@ -132,7 +134,7 @@ export default class CatalogBrowse extends React.Component {
             <CatalogFacets facets={facets} handleCategorySelect={this.handleFacetSelections} />
           </Col>
           <Col sm={9}>
-            <CatalogSearchBar helper={helper} handleSearch={this.handleSearch} />
+            <CatalogSearchBar helper={helper} handleSearch={this.handleSearch} searchTerm={searchTerm} />
             {listItems}
             <Pagination
               bsSize='large'

--- a/app/components/Catalog/CatalogFacets.jsx
+++ b/app/components/Catalog/CatalogFacets.jsx
@@ -18,7 +18,6 @@ export default class CatalogFacets extends React.Component {
     }.bind(this))
 
     var departments = facets.departments.map(function (cat, i) {
-      console.log(cat.isRefined)
       return <Input
         type='radio'
         name='departmentOptions'

--- a/app/components/Catalog/CatalogSearchBar.jsx
+++ b/app/components/Catalog/CatalogSearchBar.jsx
@@ -8,15 +8,21 @@ export default class CatalogSearchBar extends React.Component {
     this.handleSearch = this.handleSearch.bind(this)
   }
 
-  handleSearch (ev) {
+  handleSearch (e) {
     let {helper} = this.props
-    helper.setQuery(ev.target.value).search()
+    helper.setQuery(e.target.value).search()
   }
 
   render () {
+    let { searchTerm } = this.props
+    let searchInput = <Input type='text' placeholder='Search' onKeyUp={this.handleSearch} />
+    if (searchTerm !== '') {
+      searchInput = <Input type='text' defaultValue={searchTerm} onKeyUp={this.handleSearch} />
+    }
+
     return (
       <div className={'catalogMainSearchBox'}>
-        <Input type='text' placeholder='Search' onKeyUp={this.handleSearch} />
+        { searchInput }
       </div>
     )
   }

--- a/app/components/Catalog/_Catalog.scss
+++ b/app/components/Catalog/_Catalog.scss
@@ -9,7 +9,6 @@
 .catalogMain{
    margin-right:1%;
    margin-left:1%;
-   margin-top:5%;
 }
 
 h3.categories{
@@ -25,7 +24,6 @@ h3.categories{
 .catalogMainSearchBox{
   margin-top:3%;
 }
-
 
 .facetCategories{
 font-size:125%;

--- a/app/components/Dataset/DatasetFrontMatter.jsx
+++ b/app/components/Dataset/DatasetFrontMatter.jsx
@@ -17,7 +17,7 @@ class DatasetFrontMatter extends Component {
           <p className={'small text-muted'}>Data last updated {dayUpdated} at {timeUpdated}</p>
         </Col>
         <Col sm={3} className={'datasetDownLoadButtons'}>
-          <ButtonGroup style={{float: 'right', marginTop: '1em'}}>
+          <ButtonGroup style={{float: 'right', marginTop: '2em'}}>
             <DownloadLinks apiDomain={apiDomain} id={id} migrationId={migrationId} />
             <Button className={'datasetLinks'} bsStyle='primary' href={`https://dev.socrata.com/foundry/${apiDomain}/${id}`} target='_blank'>API</Button>
           </ButtonGroup>

--- a/app/components/Dataset/_Dataset.scss
+++ b/app/components/Dataset/_Dataset.scss
@@ -56,29 +56,6 @@
 	float: right;
 }
 
-.homepage{
-  margin:10%
-}
-
-#search-catalog-input::-webkit-input-placeholder {
-    color:    #99b5c3;
- }
-search-catalog-input:-moz-placeholder {
-    color:    #99b5c3;
-}
-#search-catalog-input::-moz-placeholder {
-    color:    #99b5c3;
-  }
-
-.search-input {
- font-size: 120%;
-      height: 60px;
-
-    padding-right:2%;
-    margin-right:0.5%;
-}
-
-
 .glyphicon.glyphicon-search {
     font-size: 28px;
 }
@@ -108,7 +85,6 @@ input-mysize{
 }
 
 .dataSetTitle{
-   margin-top:6%;
    font-family: 'Lato', sans-serif;
 }
 

--- a/app/components/HomePage/HomePage.jsx
+++ b/app/components/HomePage/HomePage.jsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { Component } from 'react'
 
-class HomePage extends React.Component {
+class HomePage extends Component {
 
   render () {
     return (

--- a/app/components/HomePage/HomePage.jsx
+++ b/app/components/HomePage/HomePage.jsx
@@ -1,25 +1,54 @@
+import './_HomePage.scss'
+
 import React, { Component } from 'react'
+import { hashHistory } from 'react-router'
 
 class HomePage extends Component {
 
+  constructor (props) {
+    super(props)
+    // temporary state with component, this will graduate later after we refactor search altogether
+    this.state = {
+      text: ''
+    }
+    this.handleSearch = this.handleSearch.bind(this)
+    this.handleTextChange = this.handleTextChange.bind(this)
+  }
+
+  handleSearch (e) {
+    e.preventDefault()
+    let text = this.state.text.trim()
+
+    if (!text) {
+      return
+    }
+
+    hashHistory.push('/catalog/?search=' + text)
+  }
+
+  handleTextChange (e) {
+    console.log(e.target.value)
+    this.setState({text: e.target.value})
+  }
+
   render () {
     return (
-      <section id='jumbo-search' className={'jumbotron jumbotron-default homepage'}>
-        <div className={'container'}>
-          <h1>Find the data you need</h1>
-          <p>Search hundreds of datasets from the City and County of San Francisco. Or browse on the <a href='#/catalog' className={'ext-sf-opendata'}>data catalog</a></p>
-          <div className={'row'}>
-            <form action='https://data.sfgov.org/data' role='form' className={'form-inline'}>
-              <div className={'col-md-9'}>
-                <input id='homepageSearch' className={'search-input form-control input-mysize'} type='text' name='search' placeholder='Search for data, etc.' />
+      <div id='main-container' className={'homePageMain container-fluid'}>
+        <section id='jumbo-search' className={'jumbotron jumbotron-default homepage'}>
+          <div className={'container'}>
+            <h1>Find the data you need</h1>
+            <p>Search hundreds of datasets from the City and County of San Francisco. Or browse on the <a href='#/catalog' className={'ext-sf-opendata'}>data catalog</a></p>
+            <div className={'row'}>
+              <div className={'col-md-12'}>
+                <form action='#' role='form' className={'form-inline'} onSubmit={this.handleSearch} >
+                  <input id='homepageSearch' className={'search-input form-control input-mysize'} type='text' name='search' placeholder='Search for things like Crime, 311 cases, lobbyists, etc.' autoComplete={'off'} onChange={this.handleTextChange} />
+                  <button className={'btn btn-default btnSearch'} type='submit'><i className={'glyphicon glyphicon-search'} /></button>
+                </form>
               </div>
-              <div className={'col-md-3'}>
-                <button className={'btn btn-default btnSearch'} type='submit'><i className={'glyphicon glyphicon-search'} /></button>
-              </div>
-            </form>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     )
   }
 }

--- a/app/components/HomePage/_HomePage.scss
+++ b/app/components/HomePage/_HomePage.scss
@@ -1,0 +1,2 @@
+@import 'toolkit';
+

--- a/app/components/HomePage/_HomePage.scss
+++ b/app/components/HomePage/_HomePage.scss
@@ -1,2 +1,43 @@
 @import 'toolkit';
 
+#jumbo-search {
+  text-align: center;
+}
+
+#search-catalog-input::-webkit-input-placeholder {
+    color: #99b5c3;
+ }
+search-catalog-input:-moz-placeholder {
+    color: #99b5c3;
+}
+#search-catalog-input::-moz-placeholder {
+    color: #99b5c3;
+  }
+
+.search-input {
+  font-size: 120%;
+  height: 60px;
+  padding-right:2%;
+  margin-right:0.5%;
+}
+
+.btnSearch {
+    color: #8b8b8b;
+    background: none;
+    border: none;
+    font-size: 24px;
+    position: absolute;
+    right: 10px;
+    top: 8px;
+    z-index: 999;
+    outline: none;
+    opacity: 0.5;
+}
+
+@media(min-width:768px) {
+.form-inline .form-control {
+    display: inline-block;
+    width: 100%;
+    vertical-align: middle;
+  }
+}

--- a/app/containers/App.jsx
+++ b/app/containers/App.jsx
@@ -19,7 +19,9 @@ class App extends Component {
     return (
       <div>
         <Navigation pages={pages} />
-        {children}
+        <div className={'content-wrapper'}>
+          {children}
+        </div>
         <Footer />
       </div>
     )

--- a/app/containers/Catalog.jsx
+++ b/app/containers/Catalog.jsx
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux'
+import Catalog from '../components/Catalog/Catalog'
+
+const mapStateToProps = (state, ownProps) => {
+  return {
+    searchTerm: ownProps.location.query.search
+  }
+}
+
+export default connect(
+  mapStateToProps
+)(Catalog)

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -3,7 +3,7 @@ import { Route, IndexRoute } from 'react-router'
 
 import App from './containers/App'
 import HomePage from './components/HomePage/HomePage'
-import Catalog from './components/Catalog/Catalog'
+import Catalog from './containers/Catalog'
 import Dataset from './containers/Dataset'
 import DatasetOverview from './containers/DatasetOverview'
 import DatasetDetails from './containers/DatasetDetails'


### PR DESCRIPTION
This PR will make sure that users can enter a search term on the home page and have it drop them into the catalog search.  This is just to make sure it does something sensible, but the future state will be an autopopulate feature that will give users the choice to go to a specific result directly or view all options.