### PR TITLE
Present relevant server error messages to user

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -259,7 +259,7 @@ export const loadQueryStateFromString = (q) => (dispatch, getState) => {
     },
     error => {
       dispatch({
-        type: QS_ERROR,
+        type: QS_FAILURE,
         message: error.message || 'Something bad happened',
         error: true
       })

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -191,7 +191,7 @@ export const UPDATE_FILTER = 'UPDATE_FILTER'
 export const APPLY_FILTER = 'APPLY_FILTER'
 export const APPLY_CHART_TYPE = 'APPLY_CHART_TYPE'
 export const UPDATE_FROM_QS = 'UPDATE_FROM_QS'
-export const QS_ERROR = 'QS_ERROR'
+export const QS_FAILURE = 'QS_FAILURE'
 
 export function addFilter (key) {
   return {

--- a/app/middleware/index.js
+++ b/app/middleware/index.js
@@ -9,12 +9,9 @@ function callApi (endpoint, transform, state, params) {
     .then((response) => response.json().then((json) => ({json, response}))
   ).then(({ json, response }) => {
     if (!response.ok) {
-      console.log('Response')
-      console.log(response)
+      json.status = response.status
       return Promise.reject(json)
     }
-
-    console.log(response)
 
     const transformed = transform(json, state, params)
 
@@ -67,7 +64,8 @@ export default (store) => (next) => (action) => {
     (error) => next(actionWith({
       type: failureType,
       status: error.status,
-      error: 'The server responded with an error: ' + error.message || 'Something bad happened'
+      error: true,
+      message: 'The server responded with an error: ' + error.status + ' ' + error.message + '. Code: ' + error.code || 'Something bad happened'
     }))
   )
 }

--- a/app/middleware/index.js
+++ b/app/middleware/index.js
@@ -9,11 +9,14 @@ function callApi (endpoint, transform, state, params) {
     .then((response) => response.json().then((json) => ({json, response}))
   ).then(({ json, response }) => {
     if (!response.ok) {
+      console.log('Response')
+      console.log(response)
       return Promise.reject(json)
     }
 
+    console.log(response)
+
     const transformed = transform(json, state, params)
-    // const nextPageUrl = null // getNextPageUrl(response)
 
     return Object.assign({},
       transformed
@@ -63,7 +66,8 @@ export default (store) => (next) => (action) => {
     })),
     (error) => next(actionWith({
       type: failureType,
-      error: error.message || 'Something bad happened'
+      status: error.status,
+      error: 'The server responded with an error: ' + error.message || 'Something bad happened'
     }))
   )
 }

--- a/app/middleware/socrata.js
+++ b/app/middleware/socrata.js
@@ -54,7 +54,6 @@ function constructQuery (state) {
   let consumerRoot = API_ROOT.split('/')[2]
   let consumer = new soda.Consumer(consumerRoot)
   let id = state.metadata.migrationId || state.metadata.id
-  id = id.substring(0, id.length - 1)
   let query = consumer.query().withDataset(id)
 
   let dateAggregation = dateBy === 'month' ? 'date_trunc_ym' : 'date_trunc_y'

--- a/app/middleware/socrata.js
+++ b/app/middleware/socrata.js
@@ -53,7 +53,7 @@ function constructQuery (state) {
 
   let consumerRoot = API_ROOT.split('/')[2]
   let consumer = new soda.Consumer(consumerRoot)
-  let id = state.metadata.migrationId || state.metadata.id
+  let id = state.metadata.migrationId || state.metadata.dataId
   let query = consumer.query().withDataset(id)
 
   let dateAggregation = dateBy === 'month' ? 'date_trunc_ym' : 'date_trunc_y'
@@ -137,9 +137,6 @@ function constructQuery (state) {
 }
 
 // Endpoints
-function endpoint500 () {
-  return 'http://httpstat.us/500'
-}
 
 function endpointApiMigration (id) {
   return API_ROOT + `api/migrations/${id}.json`
@@ -160,7 +157,7 @@ function endpointQuery (state) {
 function endpointTableQuery (state) {
   let consumerRoot = API_ROOT.split('/')[2]
   let consumer = new soda.Consumer(consumerRoot)
-  let id = state.metadata.migrationId || state.metadata.id
+  let id = state.metadata.migrationId || state.metadata.dataId
   let table = state.metadata.table
   let page = table.tablePage || 0
 
@@ -189,8 +186,15 @@ function endpointColumnProperties (id, key) {
 // Transforms
 
 function transformMetadata (json) {
+  let dataId = json['id']
+
+  if (json.childViews) {
+    dataId = json.childViews[0]
+  }
+
   let metadata = {
     id: json['id'],
+    dataId,
     name: json['name'],
     description: json['description'],
     type: json['viewType'],

--- a/app/middleware/socrata.js
+++ b/app/middleware/socrata.js
@@ -54,6 +54,7 @@ function constructQuery (state) {
   let consumerRoot = API_ROOT.split('/')[2]
   let consumer = new soda.Consumer(consumerRoot)
   let id = state.metadata.migrationId || state.metadata.id
+  id = id.substring(0, id.length - 1)
   let query = consumer.query().withDataset(id)
 
   let dateAggregation = dateBy === 'month' ? 'date_trunc_ym' : 'date_trunc_y'
@@ -137,6 +138,9 @@ function constructQuery (state) {
 }
 
 // Endpoints
+function endpoint500 () {
+  return 'http://httpstat.us/500'
+}
 
 function endpointApiMigration (id) {
   return API_ROOT + `api/migrations/${id}.json`

--- a/app/reducers/messagesReducer.js
+++ b/app/reducers/messagesReducer.js
@@ -16,7 +16,8 @@ function clearAllMessages (state, action) {
 
 export const messagesReducer = (state = initialState, action) => {
   switch (action.type) {
-    case ActionTypes.QS_ERROR: return setMessage(state, action)
+    case ActionTypes.QS_FAILURE:
+    case ActionTypes.DATA_FAILURE: return setMessage(state, action)
     case ActionTypes.SELECT_COLUMN: return clearAllMessages(state, action)
     default:
       return state

--- a/app/reducers/messagesReducer.js
+++ b/app/reducers/messagesReducer.js
@@ -17,7 +17,10 @@ function clearAllMessages (state, action) {
 export const messagesReducer = (state = initialState, action) => {
   switch (action.type) {
     case ActionTypes.QS_FAILURE:
+    case ActionTypes.COUNT_FAILURE:
+    case ActionTypes.COLPROPS_FAILURE:
     case ActionTypes.DATA_FAILURE: return setMessage(state, action)
+    case ActionTypes.METADATA_REQUEST:
     case ActionTypes.SELECT_COLUMN: return clearAllMessages(state, action)
     default:
       return state


### PR DESCRIPTION
## What does it do?

Partially addresses #84 

Passes errors from the API middleware to the UI, when appropriate. Specifically focused on data fetching errors. Charts won't load if Socrata is experiencing an issue so this will let users know.

## What else should you know?

There's plenty we can do to refine where messages show up, how they're styled and what instructions are given to users for certain errors to make them more useful. We can capture follow up tasks to refine this feature more based on user feedback.

For example, on 500 errors pass a message that indicates Socrata may be down, encourage them to check status.socrata.com, email support@socrata.com and try again later.

## Related issues

#84 - useful error messages presented to user

## Screenshots

A 404 error (dataset missing):

![screen shot 2017-01-23 at 11 02 10 am](https://cloud.githubusercontent.com/assets/534176/22220591/1b29fd12-e164-11e6-8fee-964fb85e6e59.png)
