### PR TITLE
Load column definitions from field definition dataset

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -17,6 +17,20 @@ function fetchMetadata (id) {
   }
 }
 
+export const COLUMNS_REQUEST = 'COLUMNS_REQUEST'
+export const COLUMNS_SUCCESS = 'COLUMNS_SUCCESS'
+export const COLUMNS_FAILURE = 'COLUMNS_FAILURE'
+
+function fetchColumns (id) {
+  return {
+    [CALL_API]: {
+      types: [COLUMNS_REQUEST, COLUMNS_SUCCESS, COLUMNS_FAILURE],
+      endpoint: Endpoints.COLUMNS(id),
+      transform: Transforms.COLUMNS
+    }
+  }
+}
+
 export const MIGRATION_REQUEST = 'MIGRATION_REQUEST'
 export const MIGRATION_FAILURE = 'MIGRATION_FAILURE'
 export const MIGRATION_SUCCESS = 'MIGRATION_SUCCESS'
@@ -67,6 +81,7 @@ export function loadMetadata (id) {
   return (dispatch, getState) => {
     return Promise.all([
       dispatch(fetchMetadata(id)),
+      dispatch(fetchColumns(id)),
       dispatch(fetchMigrationId(id)),
       dispatch(countRows(id)),
       dispatch(loadColumnProps())

--- a/app/components/Dataset/DatasetDetails.jsx
+++ b/app/components/Dataset/DatasetDetails.jsx
@@ -32,7 +32,6 @@ class DatasetDetails extends Component {
 
   render () {
     let { columns } = this.props
-    console.log(columns)
     let rows = []
     if (columns) {
       let keys = Object.keys(columns)

--- a/app/components/Dataset/DatasetDetails.jsx
+++ b/app/components/Dataset/DatasetDetails.jsx
@@ -31,7 +31,8 @@ class DatasetDetails extends Component {
   }
 
   render () {
-    let { columns } = this.props.metadata
+    let { columns } = this.props
+    console.log(columns)
     let rows = []
     if (columns) {
       let keys = Object.keys(columns)

--- a/app/components/Table/DataTable.jsx
+++ b/app/components/Table/DataTable.jsx
@@ -94,8 +94,8 @@ class DataTable extends Component {
   }
 
   render () {
-    let { metadata } = this.props
-    let { columns, table, rowCount } = metadata
+    let { metadata, columns } = this.props
+    let { table, rowCount } = metadata
     let tableContainer = null
 
     if (table && table.data && table.data.length > 0) {

--- a/app/containers/DataTable.jsx
+++ b/app/containers/DataTable.jsx
@@ -3,9 +3,10 @@ import { loadTable, sortColumn, updatePage } from '../actions'
 import DataTable from '../components/Table/DataTable'
 
 const mapStateToProps = (state, ownProps) => {
-  const { metadata } = state
+  const { metadata, columnProps } = state
   return {
-    metadata
+    metadata,
+    columns: columnProps.columns
   }
 }
 

--- a/app/containers/DatasetDetails.jsx
+++ b/app/containers/DatasetDetails.jsx
@@ -2,9 +2,10 @@ import { connect } from 'react-redux'
 import DatasetDetails from '../components/Dataset/DatasetDetails'
 
 const mapStateToProps = (state, ownProps) => {
-  const { metadata } = state
+  const { metadata, columnProps } = state
   return {
-    metadata
+    metadata,
+    columns: columnProps.columns
   }
 }
 

--- a/app/middleware/socrata.js
+++ b/app/middleware/socrata.js
@@ -10,6 +10,7 @@ const API_ROOT = 'https://data.sfgov.org/'
 // Export constants
 export const Endpoints = {
   METADATA: endpointMetadata,
+  COLUMNS: endpointColumns,
   QUERY: endpointQuery,
   TABLEQUERY: endpointTableQuery,
   COUNT: endpointCount,
@@ -19,6 +20,7 @@ export const Endpoints = {
 
 export const Transforms = {
   METADATA: transformMetadata,
+  COLUMNS: transformColumns,
   QUERY: transformQueryData,
   TABLEQUERY: transformTableQuery,
   COUNT: transformCount,
@@ -154,6 +156,10 @@ function endpointQuery (state) {
   return constructQuery(state)
 }
 
+function endpointColumns (id) {
+  return API_ROOT + `resource/cq5k-ka7d.json?$where=datasetid='${id}'`
+}
+
 function endpointTableQuery (state) {
   let consumerRoot = API_ROOT.split('/')[2]
   let consumer = new soda.Consumer(consumerRoot)
@@ -240,6 +246,23 @@ function transformMetadata (json) {
   }
 
   return metadata
+}
+
+function transformColumns (json) {
+  let response = {}
+  let columns = {}
+  for (let column of json) {
+    columns[column['api_key']] = {
+      id: column['columnid'],
+      key: column['api_key'],
+      name: column['field_name'].replace(/[_-]/g, ' '),
+      alias: column['field_alias'] || '',
+      description: column['field_definition'] || ''
+    }
+  }
+  response.columns = columns
+
+  return response
 }
 
 function transformQueryDataLegacy (json, state) {

--- a/app/reducers/columnsReducer.js
+++ b/app/reducers/columnsReducer.js
@@ -67,6 +67,10 @@ function initColumns (state, action) {
   })
 }
 
+function updateColumns (state, action) {
+  return merge({}, state, action.response)
+}
+
 function loadColumnProperties (state, action) {
   action.response.categoryColumns = union([], state.categoryColumns, action.response.categoryColumns)
   return merge({}, state, action.response)
@@ -74,6 +78,7 @@ function loadColumnProperties (state, action) {
 
 const columnsReducer = createReducer({}, {
   [ActionTypes.METADATA_SUCCESS]: initColumns,
+  [ActionTypes.COLUMNS_SUCCESS]: updateColumns,
   [ActionTypes.COLPROPS_SUCCESS]: loadColumnProperties
 })
 


### PR DESCRIPTION
## What does it do?

Primarily addresses #212 and addresses some other things that didn't have issues.

Loads field definitions from the [field definition dataset](https://data.sfgov.org/City-Management-and-Ethics/-alpha-Field-Dictionary-for-Open-Data-Portal-Datas/wn8x-uk7i) on the open data portal. It just merges content into the existing columns state object. 

To do this, I:

1. [Created an action creator fetchColumns()](https://github.com/DataSF/open-data-explorer/compare/feat/load-columns?expand=1#diff-1da453d4a7ef44b89b36dc42d56fae10R20)
2. Adjusted the socrata middleware to include an [endpoint](https://github.com/DataSF/open-data-explorer/pull/220/files#diff-9d71e07c19fb2f3fdc20199771358b4bR13) and [transform](https://github.com/DataSF/open-data-explorer/pull/220/files#diff-9d71e07c19fb2f3fdc20199771358b4bR23) for the api call
3. [Modified the columnsReducer to include a slice reducer updateColumns()](https://github.com/DataSF/open-data-explorer/pull/220/files#diff-7b8f26b455f431421d78cdc4a7f34e31R70)

These three together will call the api, process the data, and pass it to the state.

Additionally:

1. [I made adjustments to the way metadata is initially bootstrapped in the action creator](https://github.com/DataSF/open-data-explorer/compare/feat/load-columns?expand=1#diff-1da453d4a7ef44b89b36dc42d56fae10R79)
2. [Added a dataId property to identify which 4x4 should be used to query data](https://github.com/DataSF/open-data-explorer/compare/feat/load-columns?expand=1#diff-9d71e07c19fb2f3fdc20199771358b4bR197)
3. [Modified transformApiMigration to write to dataId property](https://github.com/DataSF/open-data-explorer/compare/feat/load-columns?expand=1#diff-9d71e07c19fb2f3fdc20199771358b4bR449)
4. Modified DatasetDetails.jsx and DataTable.jsx to use the new columns property

## What else should you know?

- It is not meant to refactor the entire column loading process, but this is an initial step
- @j9recurses and I talked about the vision for caching profiled information on fields and how to hook this up here; we'll create an Epic and supporting tasks to help realize this feature.

## Related issues

#212 - Pull column information from dataset
#219 - Epic created for field definitions and profiles