### PR TITLE
Modify download/api button layout

### DIFF
--- a/app/components/Dataset/Dataset.jsx
+++ b/app/components/Dataset/Dataset.jsx
@@ -13,6 +13,7 @@ class Dataset extends Component {
 
   render () {
     const { metadata, children, ...other } = this.props
+    console.log(metadata)
     return (
       <section id={'Dataset'}>
         <div className='container-fluid datasetContainer'>

--- a/app/components/Dataset/DatasetDownloads.jsx
+++ b/app/components/Dataset/DatasetDownloads.jsx
@@ -12,10 +12,10 @@ class DownloadLinks extends Component {
 
   render () {
     let options = Object.keys(downloadTypes)
-    let { apiDomain, id, migrationId } = this.props
+    let { apiDomain, id, dataId } = this.props
 
-    if (migrationId) {
-      id = migrationId
+    if (dataId) {
+      id = dataId
     }
     let menuItems = options.map(function (type, i) {
       let downloadLink = 'https://' + apiDomain + '/resource/' + id + '.' + type + '?$limit=99999999999'
@@ -27,7 +27,7 @@ class DownloadLinks extends Component {
     })
 
     return (
-      <DropdownButton title='Download' id='bg-nested-dropdown' bsStyle='primary' className={'datasetLinks'}>
+      <DropdownButton title='Download' id='bg-nested-dropdown' bsStyle='primary' bsSize='small' className={'datasetLinks'}>
         {menuItems}
       </DropdownButton>
     )

--- a/app/components/Dataset/DatasetFrontMatter.jsx
+++ b/app/components/Dataset/DatasetFrontMatter.jsx
@@ -7,19 +7,19 @@ import moment from 'moment'
 
 class DatasetFrontMatter extends Component {
   render () {
-    const { name, id, rowsUpdatedAt, apiDomain, migrationId } = this.props
+    const { name, id, rowsUpdatedAt, apiDomain, dataId } = this.props
     let dayUpdated = moment.unix(rowsUpdatedAt).format('MM/DD/YYYY')
     let timeUpdated = moment.unix(rowsUpdatedAt).format('hh:mm A')
     return (
       <Row className={'dataSetTitle'} id='header'>
-        <Col sm={9}>
+        <Col sm={8} md={9}>
           <h1 className={'datasetName'}> {name}</h1>
           <p className={'small text-muted'}>Data last updated {dayUpdated} at {timeUpdated}</p>
         </Col>
-        <Col sm={3} className={'datasetDownLoadButtons'}>
+        <Col sm={4} md={3} className={'datasetDownLoadButtons'}>
           <ButtonGroup style={{float: 'right', marginTop: '2em'}}>
-            <DownloadLinks apiDomain={apiDomain} id={id} migrationId={migrationId} />
-            <Button className={'datasetLinks'} bsStyle='primary' href={`https://dev.socrata.com/foundry/${apiDomain}/${id}`} target='_blank'>API Docs</Button>
+            <DownloadLinks apiDomain={apiDomain} id={id} dataId={dataId} />
+            <Button className={'datasetLinks'} bsStyle='primary' bsSize='small' href={`https://dev.socrata.com/foundry/${apiDomain}/${id}`} target='_blank'>API Docs</Button>
           </ButtonGroup>
         </Col>
       </Row>

--- a/app/components/Dataset/_Dataset.scss
+++ b/app/components/Dataset/_Dataset.scss
@@ -85,7 +85,6 @@ input-mysize{
 }
 
 .datasetLinks{
-  font-size:105%;
   background-color: #476481
 }
 

--- a/app/scss/bootstrap/pre-customizations.scss
+++ b/app/scss/bootstrap/pre-customizations.scss
@@ -53,10 +53,10 @@ $font-size-base:          15px !default;
 $font-size-large:         ceil(($font-size-base * 1.25)) !default; // ~18px
 $font-size-small:         ceil(($font-size-base * 0.85)) !default; // ~12px
 
-$font-size-h1:            floor(($font-size-base * 2.6)) !default; // ~36px
-$font-size-h2:            floor(($font-size-base * 2.15)) !default; // ~30px
-$font-size-h3:            ceil(($font-size-base * 1.7)) !default; // ~24px
-$font-size-h4:            ceil(($font-size-base * 1.25)) !default; // ~18px
+$font-size-h1:            floor(($font-size-base * 2.1)) !default; // ~36px
+$font-size-h2:            floor(($font-size-base * 1.7)) !default; // ~30px
+$font-size-h3:            ceil(($font-size-base * 1.3)) !default; // ~24px
+$font-size-h4:            ceil(($font-size-base * 1.1)) !default; // ~18px
 $font-size-h5:            $font-size-base !default;
 $font-size-h6:            ceil(($font-size-base * 0.85)) !default; // ~12px
 


### PR DESCRIPTION
Want to merge changes from #220 before merging this

### What it does

Addresses #153 by

1. Modifying base header sizes in bootstrap customizations
2. Adjusting column size on small screens
3. Adjusting button size

### Things to know

1. Modified download buttons to use the new dataId property to connect to the right endpoint, however it depends on changes in #220 to fully work

### Screenshots

On a 768 width screen:
![screen shot 2017-01-24 at 4 27 41 pm](https://cloud.githubusercontent.com/assets/534176/22272950/60ef628a-e252-11e6-8d50-1731ef17291f.png)


