### PR TITLE
Update getSelectableColumns to return data for field details

### DIFF
--- a/src/containers/TypeFilter.js
+++ b/src/containers/TypeFilter.js
@@ -76,7 +76,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   onFilter: item => dispatch(filterColumnList('typeFilters', item)),
   onSelectColumn: (key) => dispatch(selectColumn(key)),
   setHideShow: showCols => dispatch(setHideShow(showCols)),
-  resetState: resetState => dispatch(resetState(), )
+  resetState: resetState => dispatch(resetState())
 })
 
 export default connect(

--- a/src/reducers/columnsReducer.js
+++ b/src/reducers/columnsReducer.js
@@ -98,10 +98,13 @@ export const getSelectedField = (state, selectedColumn) => {
   }).sort(sortColumns)
 }
 
-export const getSelectableColumns = (state, selectedColumn) => {
+export const getSelectableColumns = (state, selectedColumn, all = false) => {
   let { columns, typeFilters, fieldNameFilter } = state
   if (!columns) return []
   return Object.keys(columns).filter((col) => {
+    // override to return all columns, not just selectable
+    if (all) return true
+
     let selectable = isSelectable(columns, col)
     if (state.showCols === 'hide' && col === selectedColumn) {
       return false
@@ -122,7 +125,9 @@ export const getSelectableColumns = (state, selectedColumn) => {
       type: columns[col].type,
       description: columns[col].description,
       isCategory: (typeof columns[col].categories !== 'undefined' && columns[col].categories.length > 0),
-      isSelected: (selectedColumn === columns[col].key)
+      isSelected: (selectedColumn === columns[col].key),
+      min: columns[col].min || null,
+      max: columns[col].max || null
     }
   }).sort(sortColumns)
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -28,8 +28,8 @@ export const getUniqueColumnTypes = (state, selectable) =>
 export const getGroupableColumns = state =>
   fromColumns.getGroupableColumns(state.columnProps, state.query.selectedColumn)
 
-export const getSelectableColumns = state =>
-  fromColumns.getSelectableColumns(state.columnProps, state.query.selectedColumn)
+export const getSelectableColumns = (state, all = false) =>
+  fromColumns.getSelectableColumns(state.columnProps, state.query.selectedColumn, all)
 
 export const getSummableColumns = state =>
   fromColumns.getSummableColumns(state.columnProps)


### PR DESCRIPTION
This is a minor change to getSelectableColumns selector to override and return all columns.

`getSelectableColumns` now accepts an optional second boolean parameter. Passing in true will return everything instead of just the selectables.

`getSelectableColumns(state, true)`

false is the default, so this is optional.

@j9recurses - give this a look and then you can just use this selector to map data onto the props for the components you're building. I tested this within the column selector and it did return everything, but let me know if you catch any issues.