### PR TITLE
more style changes; redesigns secondary navbar

### DIFF
--- a/src/components/ChartExperimental/ChartExperimentalAreaStuff.jsx
+++ b/src/components/ChartExperimental/ChartExperimentalAreaStuff.jsx
@@ -81,7 +81,7 @@ class ChartExperimentalAreaStuff extends Component {
             <CartesianGrid  stroke='#eee' strokeDasharray='3 3' vertical={false} />
             <Tooltip />
             <Area
-              type='monotone'
+              type='linear'
               dataKey='value'
               stroke={fillColor}
               fill={fillColor} />

--- a/src/components/Dataset/@Dataset.scss
+++ b/src/components/Dataset/@Dataset.scss
@@ -8,6 +8,9 @@
 	margin-right: 0;
 }
 
+#data-table{
+    margin-top: 1em;
+}
 #data-table .pagination {
 	float: right;
 }
@@ -81,6 +84,11 @@ input-mysize{
 }
 .datasetName{
   padding-left:2%;
+  float:left;
+  font-family: Lato,Helvetica Neue,Helvetica,Arial,sans-serif;
+    font-weight: 400;
+    line-height: 1.1;
+    color: inherit;
 }
 
 .datasetLinks{
@@ -166,25 +174,41 @@ input-mysize{
 /* Dataset Nav */
 
 .DatasetNav .nav-pills {
-  margin-bottom: 1em;
 }
 
 .DatasetNav .nav-pills > li > a {
-  border: thin solid #ecf0f1;
-
+  /*border: thin solid #ecf0f1;*/
+   border-bottom: 2px solid #ecf0f1;
+    border-top: 2px solid #ecf0f1;
+ border-radius: 0px 0px 0px 0px;
+ position: relative;
+    display: block;
+    padding: 10px 15px;
+      font-size:120%;
 }
 .DatasetNav .nav-pills > li.active > a {
- background-color: #476481
-
+ /*background-color: #476481*/
+ border-bottom: 2px solid #476481;
+ border-top: 2px solid #476481;
+background-color: #fff;
+color:#18BC9C;
+border-radius: 0px 0px 0px 0px;
+position: relative;
+    display: block;
+    padding: 10px 15px;
+    font-size:120%;
 }
 .dataset-nav-btns{
-  padding-left:1%;
+  padding-left:2%;
   margin-top:-.75%;
 }
 
 .last-updted{
-  font-size:150%;
+  font-size:125%;
   padding-left:2%;
+  float:left;
+  padding-bottom:1%;
+  padding-top:0.25%;
 }
 
 

--- a/src/components/Dataset/DatasetDownloads.jsx
+++ b/src/components/Dataset/DatasetDownloads.jsx
@@ -27,7 +27,7 @@ class DownloadLinks extends Component {
     })
 
     return (
-      <DropdownButton title='Download' id='bg-nested-dropdown' bsStyle='primary'  className={'datasetLinks'}>
+      <DropdownButton title='Download' id='bg-nested-dropdown' bsStyle='primary' bsSize={'small'} className={'datasetLinks'}>
         {menuItems}
       </DropdownButton>
     )

--- a/src/components/Dataset/DatasetFrontMatter.jsx
+++ b/src/components/Dataset/DatasetFrontMatter.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react'
 import { Row, Col, Button, ButtonGroup } from 'react-bootstrap'
 import DownloadLinks from './DatasetDownloads'
 import moment from 'moment'
-
+// '2em'
 class DatasetFrontMatter extends Component {
   render () {
     console.log(this.props)
@@ -13,19 +13,27 @@ class DatasetFrontMatter extends Component {
     let dayUpdated = moment(rowsUpdatedAt).format('MM/DD/YYYY')
     let timeUpdated = moment(rowsUpdatedAt).format('hh:mm A')
     return (
+      <div>
       <Row className={'dataSetTitle'} id='header'>
-        <Col sm={8} md={7}>
-          <h1 className={'datasetName'}> {name}</h1>
-          <p className={'text-muted last-updted'}> Data last updated {days_since_last_update} days ago on {dayUpdated} at {timeUpdated}</p>
+        <Col sm={8} md={8}>
+          <Row>
+            <Col sm={12} md={12} className={'dataset-menu'}>
+              <h1 className={'datasetName'}> {name}</h1>
+              <div className={'datasetDownLoadButtons'}>
+                <ButtonGroup style={{float: 'left', marginTop: '12%', marginRight:'-3%'}}>
+                <DownloadLinks apiDomain={apiDomain} id={id} dataId={dataId} />
+                <Button className={'datasetLinks'}  bsSize={'small'} bsStyle='primary' href={`https://dev.socrata.com/foundry/${apiDomain}/${dataId}`} target='_blank'>API Docs</Button>
+                </ButtonGroup>
+              </div>
+            </Col>
+          </Row>
         </Col>
-        <Col sm={3} md={4} className={'datasetDownLoadButtons'}>
-          <ButtonGroup style={{float: 'right', marginTop: '2em'}}>
-            <DownloadLinks apiDomain={apiDomain} id={id} dataId={dataId} />
-            <Button className={'datasetLinks'} bsStyle='primary' href={`https://dev.socrata.com/foundry/${apiDomain}/${dataId}`} target='_blank'>API Docs</Button>
-          </ButtonGroup>
-        </Col>
-         <Col sm={1} md={1} className={'datasetDownLoadButtons'}></Col>
+        <Col sm={5} md={5}></Col>
       </Row>
+      <Row>
+      <div className={'text-muted last-updted'}> Data last updated {days_since_last_update} days ago on {dayUpdated} at {timeUpdated}</div>
+      </Row>
+      </div>
     )
   }
 }

--- a/src/components/Dataset/DatasetNav.jsx
+++ b/src/components/Dataset/DatasetNav.jsx
@@ -23,10 +23,11 @@ class DatasetNav extends Component {
     if (!active) active = 'overview'
     return (
       <Row className={'chartTabs DatasetNav'}>
-        <Col sm={12}>
+        <Col sm={8} md={6} lg={6}>
         <div  className={'dataset-nav-btns'}>
           <Nav
-            bsStyle='pills'
+            bsStyle={'pills'}
+            className={'nav-justified'}
             activeKey={active}
             onSelect={this.handleTabSelect}>
             <NavItem eventKey={'overview'} className={'tabSelected'}>

--- a/src/components/FieldProfile/@FieldProfile.scss
+++ b/src/components/FieldProfile/@FieldProfile.scss
@@ -31,7 +31,7 @@ $geometry-multi-line-color: #242F75;
   margin-right:10%;
   width:100%;
   padding-top:2%;
-  border-top-width: 2px;
+  border-top-width: 4px;
   column-break-inside: avoid;
   display: inline-block;
   border-bottom:1px solid #d3d3d3;
@@ -60,28 +60,40 @@ $geometry-multi-line-color: #242F75;
 
 
 .profile-field-name {
-  font-size: 325%;
-  padding-top:3%;
+  font-size: 300%;
+  padding-top:2.5%;
   padding-bottom:0%;
+  margin-bottom:-0.25%;
   margin-top:-1%;
+  margin-left:1%;
  }
 
 
 .profile-type {
   font-size: 225%;
   font-style: italic;
-  padding-bottom:1%;
+  margin-bottom:-0.5%;
+  margin-left:1%;
 }
 
 .profile-description{
-  margin-right:3%;
-  font-size:130%;
-  width:100%;
+  font-size:140%;
+  width:90%;
+  margin-top:2%;
+  margin-right:2%;
+  margin-left:1%;
+  padding-bottom:1%;
+  display: inline-block;
+  word-break: break-all;
+  -webkit-hyphens: auto;
+   -moz-hyphens: auto;
+    -ms-hyphens: auto;
+        hyphens: auto;
 }
 
 .profile-api-key{
   font-size:130%;
-  padding-bottom:1%;
+  margin-left:1%;
 }
 
 .profile-field-remove{
@@ -107,7 +119,7 @@ $geometry-multi-line-color: #242F75;
   padding-right:4%;
   font-weight: bold;
   text-overflow: ellipsis;
-   width:40%;
+  width:40%;
 }
 
 .profile-stats-value{
@@ -124,13 +136,16 @@ $geometry-multi-line-color: #242F75;
 }
 
 .profile-stats-container{
-  padding-top:2%;
-  padding-left:1%;
-  padding-bottom:4%;
+  margin:2%;
+  padding-top:1.5%;
+  border: 1px solid #d3d3d3;
+  border-radius: 10px;
+  width:80%;
 }
+
 .profile-stats-tbl-header{
-  font-size:200%;
-  padding-bottom:1%;
+  font-size:250%;
+  padding-left:1%;
 }
 
 .profile-categories-container{

--- a/src/components/FieldProfile/index.js
+++ b/src/components/FieldProfile/index.js
@@ -136,6 +136,7 @@ class FieldProfile extends Component {
                 <div className={'text-muted profile-api-key'}>
                   {'API Key: ' + field.key}
                 </div>
+
                 <CardText className={'text-left profile-description'}>{field.description}</CardText>
           </CardBlock>
           </div>
@@ -145,7 +146,7 @@ class FieldProfile extends Component {
               <div className='profile-stats-container'>
                 <div className={'profile-stats-tbl-header'}>
                 {'Field Profile Stats'}
-              </div>
+                </div>
               <table className={'profile-stats'}>
                 <tbody>{rows}</tbody>
               </table>

--- a/src/components/MetadataCard/@MetadataCard.scss
+++ b/src/components/MetadataCard/@MetadataCard.scss
@@ -16,13 +16,13 @@ $geometry-multi-line-color: #242F75;
   margin-left:2%;
   margin-right:10%;
   width:100%;
-  padding-top:2%;
+  padding-top:1%;
   border-top-width:2px;
   border-right: 1px solid #d3d3d3;
   border-left: 1px solid #d3d3d3;
   border-bottom:1px solid #d3d3d3;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  /*border-top-right-radius: 4px;
+  border-top-left-radius: 4px;*/
   column-break-inside: avoid;
   display: inline-block;
 }

--- a/src/containers/@containers.scss
+++ b/src/containers/@containers.scss
@@ -137,9 +137,8 @@
 }
 
 .columnDetailsContainer{
-  margin-right:5%;
+  margin-right:2%;
   margin-left:0.5%;
- padding:2%;
   border-top-right-radius: 4px;
   border-top-left-radius: 4px;
 }
@@ -157,12 +156,12 @@
 }
 
 .column-details-all-container{
-  overflow:scroll;
+  padding-left:1%;
 }
 
 .fieldProfileContainer{
   margin-right:5%;
-  margin-left:-2%;
+  margin-left: -0.25%;
 }
 
 .field-details-panel-picker-container{

--- a/src/containers/ColumnDetails.js
+++ b/src/containers/ColumnDetails.js
@@ -12,7 +12,7 @@ import FieldNameFilterDetails from '../containers/FieldNameFilterDetails'
 import { Panel } from 'react-bootstrap'
 import FieldProfile from '../components/FieldProfile'
 
-const ColumnDetails = ({list, filters, onFilter, sort, onSort, items, selectableColumns, onSelectColumn, selectedColumnDef, hideshowVal, selectedField, setHideShow, showCols, selectedProfileInfo, selectedCategories }) => (
+const ColumnDetails = ({list, filters, onFilter, sort, onSort, fieldTypeItems, selectableColumns, onSelectColumn, selectedColumnDef, hideshowVal, selectedField, setHideShow, showCols, selectedProfileInfo, selectedCategories }) => (
   <Row className={'column-details-all-container'}>
     <Col sm={3} className={'field-details-panel-picker-container'}>
     <div>
@@ -38,7 +38,7 @@ const ColumnDetails = ({list, filters, onFilter, sort, onSort, items, selectable
               <DefaultListGroup
                 itemComponent={FieldTypeButton}
                 className={'default-list-group'}
-                items={items}
+                items={fieldTypeItems}
                 onSelectListItem={onFilter} />
               <FieldNameFilterDetails />
               <DefaultListGroup
@@ -56,7 +56,7 @@ const ColumnDetails = ({list, filters, onFilter, sort, onSort, items, selectable
           <DefaultListGroup
             itemComponent={FieldTypeButton}
             className={'default-list-group'}
-            items={items}
+            items={fieldTypeItems}
             onSelectListItem={onFilter} />
           <FieldNameFilterDetails />
           <DefaultListGroup
@@ -98,7 +98,7 @@ const mapStateToProps = (state, ownProps) => {
   let selectable = getSelectableColumnsDetails(state)
   return {
     list: selectable  || {},
-    items: getUniqueColumnTypesDetails(state, true),
+    fieldTypeItems: getUniqueColumnTypesDetails(state, true),
     selectableColumns: getSelectableColumnsDetails(state),
     selectedColumn: state.fieldDetailsProps.selectedColumn,
     selectedColumnDef: getSelectedFieldDef(state),


### PR DESCRIPTION
This branch contains mostly css style changes to the metadata and field profile cards. 
Also, it restyles the the secondary nav bar. Pictures below show the change:
Previous styles for the secondary nav bar:
<img width="1280" alt="screen shot 2017-07-06 at 11 44 56 am" src="https://user-images.githubusercontent.com/6549842/27927654-57a68fa4-6241-11e7-97ad-2b2d497dfc04.png">

This branch styles the nav bar like this: 
<img width="1280" alt="screen shot 2017-07-06 at 11 51 42 am" src="https://user-images.githubusercontent.com/6549842/27927707-80b29cf8-6241-11e7-9ed8-e63beef90223.png">
