### PR TITLE
switch to browser history

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import './styles/bootstrap-explorer.css'
 import React from 'react'
 import { render } from 'react-dom'
-import { hashHistory } from 'react-router'
+import { browserHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
 import Root from './containers/Root'
 import configureStore from './store/configureStore'
@@ -26,7 +26,7 @@ const initialState = {
   }
 }
 const store = configureStore(initialState)
-const history = syncHistoryWithStore(hashHistory, store)
+const history = syncHistoryWithStore(browserHistory, store)
 render(
   <Root store={store} history={history} />,
   document.getElementById('root')


### PR DESCRIPTION
This switches the app to browserHistory instead of hashHistory

Server should be configured on staging to support. We'll test there and copy over the config to production for eventual deployment against master.

Begins to address #123 