### PR TITLE
fix environment variable not showing on component errors in airbrake

### DIFF
--- a/src/middleware/airbrake.js
+++ b/src/middleware/airbrake.js
@@ -9,7 +9,13 @@ export default function middlewareFactory(credentials, notify = {}) {
   }
 
   const airbrake = new airbrakeJs(credentials)
+  airbrake.addFilter(notice => {
+    notice.context.environment = process.env.REACT_APP_CONTEXT
+    return notice
+  })
+
   const airbrakeLog = (error, params) => {
+    debugger
     airbrake.addFilter(notice => {
       notice.params = { ...(notice.params || {}), ...params }
       return notice


### PR DESCRIPTION
Finally fixes the issue where the environment wasn't being passed along in the airbrake reports.