### PR TITLE
Fix various issues with the chart configuration panel

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -237,6 +237,8 @@ export function selectColumn (column) {
     if (column !== null) {
       dispatch(fetchData(getState()))
       dispatch(setDefaultChartType(column))
+    } else if (column === null) {      
+      dispatch(resetState('query'))
     }
   }
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -128,8 +128,6 @@ export function loadFieldProps () {
   }
 }
 
-
-
 export function loadColumnProps () {
   return (dispatch, getState) => {
     // let id = getState().metadata.migrationId ? getState().metadata.migrationId : getState().metadata.id

--- a/src/components/ChartExperimental/ChartExperimental.jsx
+++ b/src/components/ChartExperimental/ChartExperimental.jsx
@@ -28,6 +28,8 @@ class ChartExperimental extends Component {
     let {columns, query, ...other} = metadata
     groupKeys = query.groupKeys
     let chartData = this.props.chart.chartData
+    // console.log("***chart data***")
+    // console.log(chartData)
     let otherProps = {...other}
     let displayChartOptions = null
     otherProps.selectedColumnDef = query.selectedColumn ? columns[query.selectedColumn] : null

--- a/src/components/ChartExperimental/ChartExperimentalCanvas.jsx
+++ b/src/components/ChartExperimental/ChartExperimentalCanvas.jsx
@@ -318,8 +318,8 @@ class ChartExperimentalCanvas extends Component {
     }
     valTickFormater = function (d) { return formatValue(d) }
     domainMax = maxValue + (maxValue * 0.05)
-    console.log("***max is here")
-    console.log(domainMax)
+    // console.log("***max is here")
+    // console.log(domainMax)
     let yTickCnt = 6
 
     //chartData = this.convertChartData(chartData, selectedColumnDef, dateBy, isGroupBy)

--- a/src/components/ChartExperimental/ChartExperimentalCanvas.jsx
+++ b/src/components/ChartExperimental/ChartExperimentalCanvas.jsx
@@ -244,7 +244,7 @@ class ChartExperimentalCanvas extends Component {
 
   isGroupByz (groupByKeys, barChartType) {
     if (groupByKeys) {
-      if (groupByKeys.length > 1) {
+      if (groupByKeys.length > 0) {
         return true
       }
     }

--- a/src/components/ChartExperimental/ChartExperimentalLineStuff.jsx
+++ b/src/components/ChartExperimental/ChartExperimentalLineStuff.jsx
@@ -8,27 +8,25 @@ class ChartExperimentalLineStuff extends Component {
 
   makeLines (groupKeys) {
     let lines = []
-    if (groupKeys) {
-      if (groupKeys.length > 1) {
-        let colorScale = d3.scale.linear().domain([1, groupKeys.length])
-          .interpolate(d3.interpolateHcl)
-          .range([d3.rgb('#007AFF'), d3.rgb('#FFF500')])
-        lines = groupKeys.map(function (i) {
-          if (i) {
-            let colorIndex = groupKeys.indexOf(i)
-            return (
-              <Line
-                type='linear'
-                dataKey={i}
-                stackId='a'
-                key={i}
-                dot={false}
-                stroke={colorScale(colorIndex)} />)
-          }
-          return false
-        })
-        return lines
-      }
+    if (groupKeys && groupKeys.length > 0) {
+      let colorScale = d3.scale.linear().domain([1, groupKeys.length])
+        .interpolate(d3.interpolateHcl)
+        .range([d3.rgb('#007AFF'), d3.rgb('#FFF500')])
+      lines = groupKeys.map(function (i) {
+        if (i) {
+          let colorIndex = groupKeys.indexOf(i)
+          return (
+            <Line
+              type='linear'
+              dataKey={i}
+              stackId='a'
+              key={i}
+              dot={false}
+              stroke={colorScale(colorIndex)} />)
+        }
+        return false
+      })
+      return lines
     }
   }
   setLegendStyleTop(lines, legendStyle){

--- a/src/components/ChartTypePicker/index.js
+++ b/src/components/ChartTypePicker/index.js
@@ -13,7 +13,7 @@ const ChartTypePicker = ({chartTypes, chartType, onChange}) => {
   })
 
   return (
-    <Panel collapsible defaultExpanded bsStyle='primary' header='Choose chart type'>
+    <Panel collapsible defaultExpanded bsStyle='primary' header={<h4>Choose a chart type <span className='glyphicon collapse-icon' ariaHidden></span></h4>}>
       {options}
     </Panel>
   )

--- a/src/components/ColumnList/index.js
+++ b/src/components/ColumnList/index.js
@@ -47,7 +47,7 @@ const sortColumns = (keys, list, sort) => {
 const ColumnList = ({list, filters, sort}) => {
   filters = filters || []
   sort = sort || 'name'
-  console.log(list)
+  // console.log(list)
   let keys = sortColumns(Object.keys(list), list, sort)
 
   let listItems = keys.map((key, idx) => {

--- a/src/components/DefaultListGroup/index.js
+++ b/src/components/DefaultListGroup/index.js
@@ -12,7 +12,7 @@ const DefaultListGroup = ({itemComponent, className, items, onSelectListItem, po
     ? items.map((item, index) => <ComponentToRender itemProps={item} key={`item-${index}`} onClick={onSelectListItem} hoverSide={hoverSide} />)
     : <div />
   }
-  console.log(items)
+  
   return (
     <ListGroup fill className={className}>
       {content}

--- a/src/components/DefaultListGroup/index.js
+++ b/src/components/DefaultListGroup/index.js
@@ -12,6 +12,7 @@ const DefaultListGroup = ({itemComponent, className, items, onSelectListItem, po
     ? items.map((item, index) => <ComponentToRender itemProps={item} key={`item-${index}`} onClick={onSelectListItem} hoverSide={hoverSide} />)
     : <div />
   }
+  console.log(items)
   return (
     <ListGroup fill className={className}>
       {content}

--- a/src/components/FilterChartOptions/@FilterOptions.scss
+++ b/src/components/FilterChartOptions/@FilterOptions.scss
@@ -16,3 +16,11 @@
   background: transparent;
   border: none;
 }
+
+.FilterChartOptions__select {
+  z-index: 10;
+}
+
+.FilterChartOptions__root .Select {
+  z-index: 9;
+}

--- a/src/components/FilterChartOptions/FilterNumeric.js
+++ b/src/components/FilterChartOptions/FilterNumeric.js
@@ -15,19 +15,27 @@ class FilterNumeric extends Component {
   }
 
   updateSliderRange (minOrMax, ev) {
-    let { nextRange } = this.props
+    let { nextRange, format, fieldKey } = this.props
     let options = {}
-    if (ev.target.value) {
-      let value = parseInt(ev.target.value, 10)
+    let value = ev.target.value
+    if (value !== '-') {
+      value = value === '' ? null : parseInt(value, 10)
+      if (format === 'percent' && value !== null) value = value / 100
+    }
+    if (value === null || value === '-' || (!isNaN(parseFloat(value)) && isFinite(value))) {
       nextRange = minOrMax === 'min' ? [value, nextRange[1]] : [nextRange[0], value]
       options.nextRange = nextRange
       options.filterType = 'numericRange'
-      this.props.updateFilter(this.props.fieldKey, options)
+      this.props.updateFilter(fieldKey, options)
     }
   }
 
   updateInputRange (value) {
+    let { format } = this.props
     let options = {}
+    if (format === 'percent') {
+      value = [value[0] / 100, value[1] / 100]
+    }
     options.nextRange = value
     options.filterType = 'numericRange'
     this.props.updateFilter(this.props.fieldKey, options)
@@ -48,27 +56,56 @@ class FilterNumeric extends Component {
   }
 
   render () {
-    let {nextRange, min, max} = this.props
+    let {nextRange, min, max, format} = this.props
     let style = {
       marginBottom: 15
     }
-    let applyOrCancel = null
+    let range = [].concat(nextRange)
+    let sliderRange = [].concat(nextRange)
+    let applyOrCancel
     if (!isEqual(this.props.currentRange, this.props.nextRange)) {
       applyOrCancel = (<div style={{textAlign: 'right', marginTop: '8px'}}><Button bsStyle='warning' bsSize='xs' onClick={this.cancelUpdate}>Cancel</Button> <Button bsStyle='success' bsSize='xs' onClick={this.applyUpdate}>Apply</Button></div>)
     }
+
+    if (nextRange[0] === null) {
+      range[0] = ''
+      sliderRange[0] = 0
+    }
+    
+    if (nextRange[1] === null) {
+      range[1] = ''
+      sliderRange[1] = 0
+    }
+
+    if (nextRange[0] === '-') {
+      sliderRange[0] = 0
+    }
+
+    if (nextRange[1] === '-') {
+      sliderRange[1] = 0
+    }
+
+    if (format === 'percent') {
+      sliderRange = [parseInt(sliderRange[0] * 100, 10), parseInt(sliderRange[1] * 100, 10)]
+      range[0] = range[0] === '' ? range[0] : parseInt(range[0] * 100, 10)
+      range[1] = range[1] === '' ? range[1] : parseInt(range[1] * 100, 10)
+      min = min * 100
+      max = max * 100
+    }
+
     return (
       <div>
         <div className='input-group input-group-sm' style={style}>
-          <input type='text' className='form-control' value={nextRange[0]} onChange={this.updateSliderRange.bind(this, 'min')} />
+          <input type='text' className='form-control' value={range[0]} onChange={this.updateSliderRange.bind(this, 'min')} />
           <span className='input-group-addon'>to</span>
-          <input type='text' className='form-control' value={nextRange[1]} onChange={this.updateSliderRange.bind(this, 'max')} />
+          <input type='text' className='form-control' value={range[1]} onChange={this.updateSliderRange.bind(this, 'max')} />
         </div>
         <Slider range
           min={min}
           max={max}
           allowCross={false}
           defaultValue={[min, max]}
-          value={nextRange}
+          value={sliderRange}
           onChange={this.updateInputRange}
           style={style} />
         {applyOrCancel}

--- a/src/components/FilterChartOptions/index.js
+++ b/src/components/FilterChartOptions/index.js
@@ -119,8 +119,9 @@ class FilterOptions extends Component {
     }
 
     return (
-      <Panel collapsible defaultExpanded header='Filter chart by other fields' bsStyle={'primary'}>
+      <Panel className={'FilterChartOptions__root'} collapsible defaultExpanded header='Filter chart by other fields' bsStyle={'primary'}>
         <Select
+          className={'FilterChartOptions__select'}
           name='filters'
           placeholder='Add fields to filter by'
           options={options}

--- a/src/components/FilterChartOptions/index.js
+++ b/src/components/FilterChartOptions/index.js
@@ -104,25 +104,14 @@ class FilterOptions extends Component {
   }
 
   render () {
-    let { handleAddFilter, columns, filters } = this.props
+    let { handleAddFilter, options, filters } = this.props
     let booleans = false
-    // todo: these are specific to Socrata, filterable columns should just be set in the state when columns are processed
-    const notFilters = ['boolean', 'location', 'url']
-
-    let options = Object.keys(columns).filter((column) => {
-      let option = columns[column]
-      if (option.unique) return false
-      if (option.type === 'boolean') booleans = true
-      if (notFilters.indexOf(option.type) > -1) return false
-      if (!option.categories && option.type === 'text') return false
-      if (option.singleValue) return false
-      return true
-    }).map((column, i) => {
-      let option = columns[column]
-      return {
-        value: option.key,
-        label: option.name
+    options = options.filter(field => {
+      if (field.type === 'boolean') {
+        booleans = true
+        return false
       }
+      return true
     })
 
     if (booleans) {
@@ -133,7 +122,7 @@ class FilterOptions extends Component {
       <Panel collapsible defaultExpanded header='Filter chart by other fields' bsStyle={'primary'}>
         <Select
           name='filters'
-          placeholder='Add filters to visualization'
+          placeholder='Add fields to filter by'
           options={options}
           onChange={handleAddFilter} />
         {filters ? this.renderFilterList() : false}

--- a/src/components/FilterChartOptions/index.js
+++ b/src/components/FilterChartOptions/index.js
@@ -24,7 +24,7 @@ class FilterOptions extends Component {
       let checkboxOptions = {}
       if (key !== 'booleans') {
         filter = columns[key]
-        filterType = (filter.type === 'text' || filter.type === 'number') && filter.categories ? 'category' : filter.type
+        filterType = (filter.type === 'text') && filter.categories ? 'category' : filter.type
       } else {
         filter = {key: 'booleans', name: 'True/False fields'}
         filterType = 'boolean'

--- a/src/components/FilterChartOptions/index.js
+++ b/src/components/FilterChartOptions/index.js
@@ -120,7 +120,7 @@ class FilterOptions extends Component {
     }
 
     return (
-      <Panel className={'FilterChartOptions__root'} collapsible defaultExpanded header='Filter chart by other fields' bsStyle={'primary'}>
+      <Panel className={'FilterChartOptions__root'} collapsible defaultExpanded header={<h4>Selected field <span className='glyphicon collapse-icon' ariaHidden></span></h4>} bsStyle={'primary'}>
         <Select
           className={'FilterChartOptions__select'}
           name='filters'

--- a/src/components/FilterChartOptions/index.js
+++ b/src/components/FilterChartOptions/index.js
@@ -81,7 +81,8 @@ class FilterOptions extends Component {
             nextRange={nextRange}
             filter={filters[key]}
             applyFilter={applyFilter}
-            updateFilter={updateFilter} />
+            updateFilter={updateFilter}
+            format={filter.format} />
           break
         default:
           return null

--- a/src/components/FilterChartOptions/index.js
+++ b/src/components/FilterChartOptions/index.js
@@ -120,7 +120,7 @@ class FilterOptions extends Component {
     }
 
     return (
-      <Panel className={'FilterChartOptions__root'} collapsible defaultExpanded header={<h4>Selected field <span className='glyphicon collapse-icon' ariaHidden></span></h4>} bsStyle={'primary'}>
+      <Panel className={'FilterChartOptions__root'} collapsible defaultExpanded header={<h4>Filter by other fields <span className='glyphicon collapse-icon' ariaHidden></span></h4>} bsStyle={'primary'}>
         <Select
           className={'FilterChartOptions__select'}
           name='filters'

--- a/src/components/PanelHeader/index.js
+++ b/src/components/PanelHeader/index.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const PanelHeader = ({title}) => (
+    <h4>{title}<span className='glyphicon collapse-icon' ariaHidden></span></h4>
+)
+
+export default PanelHeader

--- a/src/components/Query/@Query.scss
+++ b/src/components/Query/@Query.scss
@@ -47,3 +47,11 @@
 .filter.well {
   z-index: 0;
 }
+
+.SumOptions__select {
+  z-index: 6;
+}
+
+.GroupOptions__select {
+  z-index: 8;
+}

--- a/src/components/Query/ChartOptions.jsx
+++ b/src/components/Query/ChartOptions.jsx
@@ -88,13 +88,11 @@ class ChartOptions extends Component {
         sumByOptions = this.renderSumByOptions()
       }
     }
-    const panelTitle = (
-      <div>Filter Options</div>
-    )
+    
     return (
       selectedColumn
       ? (
-        <Panel collapsible defaultExpanded className='chart' header={panelTitle}>
+        <Panel collapsible defaultExpanded className='chart' header={<h4>Filter options <span className='glyphicon collapse-icon' ariaHidden></span></h4>}>
           {sumByOptions}
         </Panel>
       ) : false

--- a/src/components/Query/GroupOptions.js
+++ b/src/components/Query/GroupOptions.js
@@ -8,7 +8,7 @@ class GroupOptions extends Component {
     let { columns, selected, onGroupBy } = this.props
     return (
       columns.length !== 0
-      ? <Panel collapsible defaultExpanded header='Group by another field' bsStyle={'primary'}>
+      ? <Panel collapsible defaultExpanded header={<h4>Group by another field <span className='glyphicon collapse-icon' ariaHidden></span></h4>} bsStyle={'primary'}>
         <Select
           className={'GroupOptions__select'}
           name='groupby'

--- a/src/components/Query/GroupOptions.js
+++ b/src/components/Query/GroupOptions.js
@@ -10,6 +10,7 @@ class GroupOptions extends Component {
       columns.length !== 0
       ? <Panel collapsible defaultExpanded header='Group by another field' bsStyle={'primary'}>
         <Select
+          className={'GroupOptions__select'}
           name='groupby'
           placeholder='Select a field to group by'
           options={columns}

--- a/src/components/Query/SumOptions.js
+++ b/src/components/Query/SumOptions.js
@@ -8,7 +8,7 @@ class SumOptions extends Component {
     let { columns, selected, onSumBy } = this.props
     return (
       columns.length !== 0
-        ? <Panel collapsible defaultExpanded header='Sum by a numeric field' bsStyle={'primary'}>
+        ? <Panel collapsible defaultExpanded header={<h4>Sum by a numeric field <span className='glyphicon collapse-icon' ariaHidden></span></h4>} bsStyle={'primary'}>
           <Select
             className={'SumOptions__select'}
             name='sumby'

--- a/src/components/Query/SumOptions.js
+++ b/src/components/Query/SumOptions.js
@@ -10,6 +10,7 @@ class SumOptions extends Component {
       columns.length !== 0
         ? <Panel collapsible defaultExpanded header='Sum by a numeric field' bsStyle={'primary'}>
           <Select
+            className={'SumOptions__select'}
             name='sumby'
             placeholder='Select a field to sum by'
             options={columns}

--- a/src/containers/@containers.scss
+++ b/src/containers/@containers.scss
@@ -173,3 +173,24 @@
 .Chart__header{
   padding-bottom:2%;
 }
+
+.panel-heading a {
+  display: block;
+  padding: 10px 15px;
+  margin: -10px -15px;
+  cursor: pointer;
+}
+
+.panel-heading .glyphicon.collapse-icon {
+  float: right;
+}
+
+a .glyphicon.collapse-icon:before {
+  content: "\e252";
+}
+
+a.collapsed .glyphicon.collapse-icon:before {
+  content: "\e253";
+}
+
+

--- a/src/containers/TypeFilter.js
+++ b/src/containers/TypeFilter.js
@@ -8,6 +8,7 @@ import FieldButton from '../components/FieldButton'
 import HideShowButton from '../components/HideShowButton/'
 import FieldNameFilter from '../containers/FieldNameFilter'
 import { Panel } from 'react-bootstrap'
+import PanelHeader from '../components/PanelHeader'
 
 const TypeFilter = ({items, selectableColumns, onFilter, onSelectColumn, selectedColumnDef, hideshowVal, selectedField, setHideShow, showCols}) => (
   <div>
@@ -15,7 +16,7 @@ const TypeFilter = ({items, selectableColumns, onFilter, onSelectColumn, selecte
       <When condition={selectedColumnDef}>
         <Choose>
           <When condition={showCols !== 'hide'}>
-            <Panel collapsible defaultExpanded bsStyle='primary' header='Selected field'>
+            <Panel collapsible defaultExpanded bsStyle='primary' header={<h4>Selected field <span className='glyphicon collapse-icon' ariaHidden></span></h4>}>
               <DefaultListGroup
                 itemComponent={FieldButton}
                 items={selectedField}
@@ -25,7 +26,7 @@ const TypeFilter = ({items, selectableColumns, onFilter, onSelectColumn, selecte
             </Panel>
           </When>
           <Otherwise>
-            <Panel collapsible defaultExpanded bsStyle='primary' header='Selected field'>
+            <Panel collapsible defaultExpanded bsStyle='primary' header={<h4>Selected field <span className='glyphicon collapse-icon' ariaHidden></span></h4>}>
               <DefaultListGroup
                 itemComponent={FieldButton}
                 items={selectedField}
@@ -48,7 +49,7 @@ const TypeFilter = ({items, selectableColumns, onFilter, onSelectColumn, selecte
         </Choose>
       </When>
       <Otherwise>
-        <Panel collapsible defaultExpanded header='Select a field' bsStyle={'primary'}>
+        <Panel collapsible defaultExpanded header={<h4>Select a field <span className='glyphicon collapse-icon' ariaHidden></span></h4>} bsStyle={'primary'}>
           <h5>Filter field list by type</h5>
           <DefaultListGroup
             itemComponent={FieldTypeButton}

--- a/src/containers/TypeFilter.js
+++ b/src/containers/TypeFilter.js
@@ -8,7 +8,6 @@ import FieldButton from '../components/FieldButton'
 import HideShowButton from '../components/HideShowButton/'
 import FieldNameFilter from '../containers/FieldNameFilter'
 import { Panel } from 'react-bootstrap'
-import PanelHeader from '../components/PanelHeader'
 
 const TypeFilter = ({items, selectableColumns, onFilter, onSelectColumn, selectedColumnDef, hideshowVal, selectedField, setHideShow, showCols}) => (
   <div>

--- a/src/containers/VizContainer.js
+++ b/src/containers/VizContainer.js
@@ -53,6 +53,7 @@ class VizContainer extends Component {
               <FilterOptions
                 filters={props.filters}
                 columns={props.columns}
+                options={props.selectableColumns}
                 handleAddFilter={actions.handleAddFilter}
                 handleRemoveFilter={actions.handleRemoveFilter}
                 applyFilter={actions.applyFilter}

--- a/src/containers/VizContainer.js
+++ b/src/containers/VizContainer.js
@@ -53,7 +53,7 @@ class VizContainer extends Component {
               <FilterOptions
                 filters={props.filters}
                 columns={props.columns}
-                options={props.selectableColumns}
+                options={props.filterableColumns}
                 handleAddFilter={actions.handleAddFilter}
                 handleRemoveFilter={actions.handleRemoveFilter}
                 applyFilter={actions.applyFilter}
@@ -196,7 +196,8 @@ const mapStateToProps = (state, ownProps) => {
       rowLabel: metadata.rowLabel,
       summableColumns: getSummableColumns(state),
       groupableColumns: getGroupableColumns(state),
-      selectableColumns: getSelectableColumns(state)
+      selectableColumns: getSelectableColumns(state),
+      filterableColumns: getSelectableColumns(state, false, true)
     }
   }
 }

--- a/src/middleware/airbrake.js
+++ b/src/middleware/airbrake.js
@@ -15,7 +15,6 @@ export default function middlewareFactory(credentials, notify = {}) {
   })
 
   const airbrakeLog = (error, params) => {
-    debugger
     airbrake.addFilter(notice => {
       notice.params = { ...(notice.params || {}), ...params }
       return notice

--- a/src/middleware/metadatasf.js
+++ b/src/middleware/metadatasf.js
@@ -51,11 +51,12 @@ function transformColumns (json) {
   result['columns'] = columns
   result.categoryColumns = json.map(function(item){
     let key
-    if(item.isCategory){
-      key =  item.key
+    if(item.isCategory && item.type.indexOf('geometry') === -1) {
+      key = item.key
     }
     return key
   }).filter(n => n)
+
   result.textColumns = json.map(function(item){
     let key
     if(item.type === 'text'){

--- a/src/middleware/socrata.js
+++ b/src/middleware/socrata.js
@@ -617,26 +617,15 @@ function transformApiMigration (json) {
   return {dataId: json.nbeId}
 }
 
+
 function transformColumnProperties (json, state, params) {
-  let maxRecord = parseInt(maxBy(json, function (o) { return parseInt(o.count, 10) },).count, 10)
-  let checkFirst = maxRecord / state.metadata.rowCount
-  let checkNumCategories = json.length / state.metadata.rowCount
-  let transformed = {
-    columns: {}
+  return {
+    columns: {
+      [params['key']]: {
+        categories: json
+      }
+    }
   }
-  transformed.columns[params['key']] = {}
-  if ((checkFirst <= 0.95 && checkFirst >= 0.05 && checkNumCategories <= 0.95) && maxRecord !== '1' && json.length !== 50000) {
-    transformed.columns[params['key']].categories = json
-    transformed.categoryColumns = [params['key']]
-  } else if (maxRecord === 1) {
-    transformed.columns[params['key']].unique = true
-  }
-
-  if (checkFirst === 1) {
-    transformed.columns[params['key']].singleValue = true
-  }
-
-  return transformed
 }
 
 

--- a/src/middleware/socrata.js
+++ b/src/middleware/socrata.js
@@ -1,5 +1,4 @@
 import soda from 'soda-js'
-import maxBy from 'lodash/maxBy'
 import uniq from 'lodash/uniq'
 import difference from 'lodash/difference'
 import { replacePropertyNameValue } from '../helpers'
@@ -30,21 +29,6 @@ export const Transforms = {
   COUNT: transformCount,
   MIGRATION: transformApiMigration,
   COLPROPS: transformColumnProperties
-}
-
-export const shouldRunColumnStats = (type, key) => {
-  /*
-   * below is a bit of a hack to get around the fact that some categorical fields are encoded as numbers on the portal
-   * we don't want to run column stats against all numeric columns, so this allows us to control that, the regex below may need to be
-   * tuned as is, it could create false positives. This is okay for now, something we can optimize later
-  */
-  let regex = /(year|day|date|month|district|yr|code|id|x|y|lat|lon)/g
-  let isCategorical = regex.test(key)
-  if (type === 'text' || (isCategorical && type === 'number')) {
-    return true
-  } else {
-    return false
-  }
 }
 
 // Construct URL based on chart options
@@ -151,7 +135,7 @@ function constructQuery (state) {
         let join = filter.options.join || 'or'
         let joined = filter.options.selected.join(' ' + join + ' ')
         query.where(joined)
-      } else if (column.type === 'number' && !column.categories && filter.options && filter.options.currentRange) {
+      } else if (column.type === 'number' && filter.options && filter.options.currentRange) {
         let first = parseInt(filter.options.currentRange[0], 10)
         let last = parseInt(filter.options.currentRange[1], 10)
         query.where(key + '>=' + first + ' and ' + key + '<=' + last)

--- a/src/reducers/columnsReducer.js
+++ b/src/reducers/columnsReducer.js
@@ -75,7 +75,7 @@ export const getGroupableColumns = (state, selectedColumn) => {
   selectedColumn = selectedColumn || ''
   if (!columns) return []
   return Object.keys(columns).filter((col) => {
-    return (columns[col].key !== selectedColumn && columns[col].categories)
+    return (columns[col].key !== selectedColumn && columns[col].categories && (columns[col].type === 'text' || (columns[col].type === 'number' && parseInt(columns[col].cardinality, 10) < 15 )))
   }).map((col) => {
     return {label: columns[col].name, value: columns[col].key}
   }).sort(sortColumns)
@@ -99,7 +99,7 @@ export const getSelectedField = (state, selectedColumn) => {
   }).sort(sortColumns)
 }
 
-export const getSelectableColumns = (state, selectedColumn, all = false) => {
+export const getSelectableColumns = (state, selectedColumn, all = false, ignoreTypeFilters = false) => {
   let { columns, typeFilters, fieldNameFilter } = state
   if (!columns) return []
   return Object.keys(columns).filter((col) => {
@@ -113,9 +113,13 @@ export const getSelectableColumns = (state, selectedColumn, all = false) => {
     if (fieldNameFilter && columns[col].name.toLowerCase().indexOf(fieldNameFilter.toLowerCase()) === -1) {
       return false
     }
+    if (ignoreTypeFilters && selectable) {
+      return true
+    }
     if (selectable && typeFilters.length > 0 && typeFilters.indexOf(columns[col].type) > -1) {
       return true
-    } else if (selectable && typeFilters.length === 0) {
+    }
+    if (selectable && typeFilters.length === 0) {
       return true
     }
     return false

--- a/src/reducers/columnsReducer.js
+++ b/src/reducers/columnsReducer.js
@@ -29,10 +29,11 @@ function sortColumns (a, b) {
 }
 
 function isSelectable (columns, col) {
-  let colTypesAccepted = ['number', 'boolean', 'date']
+  let colTypesAccepted = ['boolean', 'date']
   let regex = /(^(lat|lon)[a-z]*|^(x|y)$)/i
   let geoFields = regex.test(columns[col].key)
-  let selectable = (!columns[col].unique && !geoFields && ((['text', 'number'].indexOf(columns[col].type) > -1) || colTypesAccepted.indexOf(columns[col].type) > -1))
+  // selectable if they are text or numeric columns that are categories and not geoFields OR is one of the type boolean, date and number
+  let selectable = ((typeof columns[col].categories !== 'undefined') && !geoFields && ['text', 'number'].indexOf(columns[col].type) > -1) || colTypesAccepted.indexOf(columns[col].type) > -1
   return selectable
 }
 

--- a/src/reducers/columnsReducer.js
+++ b/src/reducers/columnsReducer.js
@@ -232,16 +232,11 @@ function setDefaultHideShow (state, action) {
 }
 
 function resetState (state, action) {
-  if (action.payload.target !== 'columnProps') {
+  if (action.payload !== 'columnProps') {
     return state
   }
   return updateObject(state, {})
 }
-
-
-
-
-
 
 const columnsReducer = createReducer({ typeFilters: [] }, {
   [ActionTypes.COLUMNS_SUCCESS]: initColumns, 

--- a/src/reducers/columnsReducer.js
+++ b/src/reducers/columnsReducer.js
@@ -135,12 +135,14 @@ export const getSelectableColumns = (state, selectedColumn, all = false) => {
 
 export const getSummableColumns = (state) => {
   let { columns } = state
-  let colTypesAccepted = ['number', 'money', 'double']
+  let colTypesAccepted = ['number']
+  let regex = /(^(lat|lon|supervisor)[a-z]*|^(x|y)$)/i
 
   if (!columns) return []
-
+  
+  
   return Object.keys(columns).filter((col) => {
-    return (!columns[col].categories && !columns[col].unique && colTypesAccepted.indexOf(columns[col].type) > -1)
+    return (parseFloat(columns[col].distinctness) < 0.95 && colTypesAccepted.indexOf(columns[col].type) > -1 && !regex.test(columns[col].name))
   }).map((col) => {
     return {label: columns[col].name, value: columns[col].key}
   }).sort(sortColumns)

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -49,8 +49,8 @@ export const getUniqueColumnTypes = (state, selectable) =>
 export const getGroupableColumns = state =>
   fromColumns.getGroupableColumns(state.columnProps, state.query.selectedColumn)
 
-export const getSelectableColumns = (state, all = false) =>
-  fromColumns.getSelectableColumns(state.columnProps, state.query.selectedColumn, all)
+export const getSelectableColumns = (state, all = false, ignoreTypeFilters = false) =>
+  fromColumns.getSelectableColumns(state.columnProps, state.query.selectedColumn, all, ignoreTypeFilters)
 
 export const getSummableColumns = state =>
   fromColumns.getSummableColumns(state.columnProps)

--- a/src/reducers/queryReducer.js
+++ b/src/reducers/queryReducer.js
@@ -71,7 +71,10 @@ function updateFilter (state, action) {
 }
 
 function resetState (state, action) {
-  return initialState
+  if (action.type === ActionTypes.METADATA_REQUEST || action.payload === 'query') {
+    return initialState
+  }
+  return state
 }
 
 function updateFromQueryString (state, action) {
@@ -80,6 +83,7 @@ function updateFromQueryString (state, action) {
 
 export const queryReducer = (state = initialState, action) => {
   switch (action.type) {
+    case ActionTypes.RESET_STATE:
     case ActionTypes.METADATA_REQUEST: return resetState(state, action)
     case ActionTypes.SELECT_COLUMN: return selectColumn(state, action)
     case ActionTypes.DATA_REQUEST: return dataRequest(state, action)


### PR DESCRIPTION
## What it does

Addresses #355 - a range of issues related to the chart configuration options (select, filter, group, sum, etc)

Including:

1. Fix selectable fields
2. Fix filterable fields - modified `getSelectableColumns()` with an option to ignore type filters called `ignoreTypeFilters`
3. Address issues related to geometry fields being treated like categories
4. Fixed an issue where line charts were not displaying when a user selects a grouping option and filters by one category in that group. There's a similar issue with bar charts that I did not fix, logged #357 
5. Fixed an issue where all options were still applied when clearing the selected column, now clearing a selected column resets the query state completely
6. Modified the panel headers to indicate visually the collapse state
7. Fixed z-index issues with selector dropdowns
8. Fixed an issue with the input range slider where empty or negative character strings would produce NaN-related errors

## Screenshots

![screen shot 2017-07-28 at 11 08 40 am](https://user-images.githubusercontent.com/534176/28730471-2e82eadc-7385-11e7-9a3d-f52d3b94b765.png)