### PR TITLE
Address multiple bugs and cosmetic issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-dimensions": "^1.2.0",
     "react-dom": "^15.5.4",
     "react-ga": "^2.2.0",
-    "react-instantsearch": "4.0.0",
+    "react-instantsearch": "^4.0.10",
     "react-radio-group": "^2.2.0",
     "react-redux": "^4.4.1",
     "react-router": "3.0.5",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -423,7 +423,7 @@ export const loadQueryStateFromString = (q) => (dispatch, getState) => {
 }
 
 export const UPDATE_SEARCH = 'UPDATE_SEARCH'
-export const CLEAR_SEARCH = 'CLEAR_SEARCH'
+export const SELECT_SEARCH_RECORD = 'SELECT_SEARCH_RECORD'
 export const SELECT_FIELD = 'SELECT_FIELD'
 export const SET_SELECTED_FIELD_DETAILS = 'SET_SELECTED_FIELD_DETAILS'
 
@@ -435,9 +435,10 @@ export function updateSearch (searchState) {
   }
 }
 
-export function clearSearch () {
+export function selectSearchRecord (record) {
   return {
-    type: CLEAR_SEARCH
+    type: SELECT_SEARCH_RECORD,
+    payload: record
   }
 }
 
@@ -471,7 +472,7 @@ function fetchRelatedDatasets (id) {
 
 export function loadRelatedDatasets (id) {
   return (dispatch, getState) => {
-    return Promise.all([dispatch(fetchRelatedDatasets(id))])
+    return dispatch(fetchRelatedDatasets(id))
   }
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -207,7 +207,7 @@ export function selectColumn (column) {
     dispatch({
       type: SELECT_COLUMN,
       payload: column})
-    dispatch(setDefaultHideShow('columnProps'))
+    dispatch(setHideShow(false, 'columnProps'))
     if (column !== null) {
       dispatch(fetchData(getState()))
       dispatch(setDefaultChartType(column))
@@ -223,7 +223,7 @@ export function selectField (column) {
       type: SELECT_FIELD,
       payload: column})
     dispatch(fetchDataTextFieldCategories(getState()))
-    dispatch(setDefaultHideShow('fieldDetailsProps'))
+    dispatch(setHideShow(false, 'fieldDetailsProps'))
   }
 }
 
@@ -232,16 +232,6 @@ export function setHideShow (showCols, target) {
     dispatch({
       type: SET_HIDE_SHOW,
       payload: {'showCols': showCols, 'target': target}
-    })
-  }
-}
-
-
-export function setDefaultHideShow (target) {
-  return (dispatch, getState) => {
-    dispatch({
-      type: SET_DEFAULT_HIDE_SHOW,
-      payload: {'showCols': 'show', 'target': target}
     })
   }
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,8 +2,6 @@ import { CALL_API } from '../middleware'
 //import { Endpoints, Transforms, shouldRunColumnStats } from '../middleware/socrata'
 
 import { Endpoints, Transforms } from '../middleware/socrata'
-
-
 import { EndpointsSF, TransformsSF } from '../middleware/metadatasf'
 
 import {isColTypeTest} from '../helpers'

--- a/src/components/AboutPage/index.js
+++ b/src/components/AboutPage/index.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import { Grid } from 'react-bootstrap'
+import { setDocumentTitle } from '../../helpers'
 
 export default class AboutPage extends React.Component {
   render () {
+    setDocumentTitle('About')
     return (
       <Grid fluid id='main-container' className={'catalogMain'}>
         <h2>This site is in ALPHA: Were just getting started and adding new features. </h2>

--- a/src/components/Catalog/@Catalog.scss
+++ b/src/components/Catalog/@Catalog.scss
@@ -194,3 +194,7 @@
 .ais-SortBy__root {
   float: right;
 }
+
+.ais-Pagination__noRefinement {
+  display: none;
+}

--- a/src/components/Catalog/@Catalog.scss
+++ b/src/components/Catalog/@Catalog.scss
@@ -18,7 +18,7 @@
   padding-top: 10px;
   padding-bottom: 15px;
   float: left;
-  max-width: 80%;
+  max-width: 77%;
 }
 
 .Catalog__sortBy {
@@ -82,7 +82,7 @@
 }
 
 .Catalog__record .panel-body {
-  background-color: #d7ffd9;
+  background-color: rgba(255,231,149,.4)
 }
 
 .Catalog__record-tags {
@@ -175,7 +175,7 @@
   position: absolute;
   right: 10px;
   top: -5px;
-  background: #a5d6a7;
+  background: #e0b566;
   box-shadow: 1px 2px 0 0 rgba(0,0,0,0.50);
   width: 200px;
   text-align: center;

--- a/src/components/Catalog/index.js
+++ b/src/components/Catalog/index.js
@@ -43,9 +43,6 @@ const Record = (onClickRecord, {hit}) => (
           <strong>Tags</strong> <span className={'App--font-thin'}>{hit.keywords.join(', ')}</span></p>
         ) : false 
       }
-      <div className={'Catalog__record-extras'}>
-          Row count: 200,000
-        </div>
     </div>
   </BSPanel>
 )

--- a/src/components/Catalog/index.js
+++ b/src/components/Catalog/index.js
@@ -14,15 +14,15 @@ const CustomStats = ({nbHits}) => <span className={'ais-Stats__root clearfix'}>{
 
 const ConnectedStats = connectStats(CustomStats)
 
-const Record = (clearSearch, {hit}) => (
+const Record = (onClickRecord, {hit}) => (
   <BSPanel 
-    header={<Link to={`${'/' + slugify(hit.category) + '/' + slugify(hit.name) + '/' + hit.systemID}`} onClick={clearSearch}>
+    header={<Link to={`${'/' + slugify(hit.category) + '/' + slugify(hit.name) + '/' + hit.objectID}`} onClick={onClickRecord.bind(this,hit)}>
         {hit.name}
       </Link>} 
     className='Catalog__record' 
     bsStyle='primary'>
     <div className={'Catalog__record-meta-dept'}>
-      <div className={'Catalog__record-meta-dept-value'}>{hit.publishing_dept}</div>
+      <div className={'Catalog__record-meta-dept-value'}>{hit.publishingDepartment}</div>
     </div>
     <div className={'Catalog__record-meta clearfix'}>
       <div className={'Catalog__record-meta-title'}>Data updated</div>
@@ -31,22 +31,27 @@ const Record = (clearSearch, {hit}) => (
       <div className={'Catalog__record-meta-value'}>{hit.publishingFrequency}</div>
       <div className={'Catalog__record-meta-title'}>Category</div>
       <div className={'Catalog__record-meta-value'}>{hit.category}</div>
+      <div className={'Catalog__record-meta-title'}>Row count</div>
+      <div className={'Catalog__record-meta-value'}>{hit.rowCount.toLocaleString()}</div>
     </div>
     <div className={'Catalog__record-description clearfix'}>
       <div className={'Catalog__record-description-text'}>
         <ReadMore text={hit.description}/>
       </div>
-      {hit.tags ? (
+      {hit.keywords ? (
         <p className={'Catalog__record-tags'}>
-          <strong>Tags</strong> <span className={'App--font-thin'}>{hit.tags.join(', ')}</span></p>
+          <strong>Tags</strong> <span className={'App--font-thin'}>{hit.keywords.join(', ')}</span></p>
         ) : false 
       }
+      <div className={'Catalog__record-extras'}>
+          Row count: 200,000
+        </div>
     </div>
   </BSPanel>
 )
 
 const labelRefinements = (items) => {
-  let labels = {'category': 'Category: ', 'publishing_dept': 'Department: ', 'fieldTypes': 'Field Types: '}
+  let labels = {'category': 'Category: ', 'publishingDepartment': 'Department: ', 'fieldTypes': 'Field Types: '}
   let transform = items.map((item) => {
     let copy = Object.assign({}, item)
     copy.label = labels[copy['attributeName']]
@@ -55,7 +60,7 @@ const labelRefinements = (items) => {
   return transform
 }
 
-const Search = ({clearSearch}) => (
+const Search = ({onClickRecord}) => (
   <Grid className={'Catalog'}>
     <Row className='Catalog__search'>
       <ScrollTo>
@@ -77,8 +82,8 @@ const Search = ({clearSearch}) => (
           items={[
             { value: 'dev_dataset_search', label: 'Most Relevant' },
             { value: 'dev_dataset_search_alpha', label: 'A to Z' },
-            { value: 'dev_dataset_search_created', label: 'Most Recently Created'},
-            { value: 'dev_dataset_search_updated', label: 'Most Recently Updated'}
+            { value: 'dev_dataset_search_created', label: 'Recently Created'},
+            { value: 'dev_dataset_search_updated', label: 'Recently Updated'}
           ]}
           defaultRefinement='dev_dataset_search'
         />
@@ -94,11 +99,11 @@ const Search = ({clearSearch}) => (
           <RefinementList className='Catalog__refine--field-types' attributeName='fieldTypes' transformItems={items => orderBy(items, ['label', 'count'], ['asc', 'desc'])} />
         </Panel>
         <Panel title='Departments'>
-          <RefinementList className='Catalog__refine--department' attributeName='publishing_dept' withSearchBox showMore limitMax={52} transformItems={items => orderBy(items, ['label', 'count'], ['asc', 'desc'])} />
+          <RefinementList className='Catalog__refine--department' attributeName='publishingDepartment' withSearchBox showMore limitMax={52} transformItems={items => orderBy(items, ['label', 'count'], ['asc', 'desc'])} />
         </Panel>
       </Col>
       <Col sm={10}>
-        <Hits hitComponent={Record.bind(this, clearSearch)} />
+        <Hits hitComponent={Record.bind(this, onClickRecord)} />
         <div className={'Catalog__pagination'}>
           <Pagination />
         </div>

--- a/src/components/ChartExperimental/ChartExperimental.jsx
+++ b/src/components/ChartExperimental/ChartExperimental.jsx
@@ -38,31 +38,24 @@ class ChartExperimental extends Component {
     let chartType = chartDisplay.chartType
     return (
       <Row>
-        <Choose>
-          <When condition={chartData.length > 0}>
-            <ChartExperimentalCanvas
-              chart={chart}
-              chartData={chartData}
-              groupKeys={groupKeys}
-              changeDateBy={changeDateBy}
-              changeRollupBy={changeRollupBy}
-              columns={columns}
-              {...otherProps}
-              query={query}
-              dateBy={query.dateBy}
-              rollupBy={query.rollupBy}
-              groupBy={query.groupBy}
-              sumBy={query.sumBy}
-              filters={query.filters}
-              chartType={chartType}
-              applyChartType={applyChartType}
-              displayChartOptions={displayChartOptions}
-            />
-          </When>
-          <When condition={chartData.length === 0}>
-            <h2> Based on your filters, your query retrieved no results </h2>
-          </When>
-        </Choose>
+        <ChartExperimentalCanvas
+          chart={chart}
+          chartData={chartData}
+          groupKeys={groupKeys}
+          changeDateBy={changeDateBy}
+          changeRollupBy={changeRollupBy}
+          columns={columns}
+          {...otherProps}
+          query={query}
+          dateBy={query.dateBy}
+          rollupBy={query.rollupBy}
+          groupBy={query.groupBy}
+          sumBy={query.sumBy}
+          filters={query.filters}
+          chartType={chartType}
+          applyChartType={applyChartType}
+          displayChartOptions={displayChartOptions}
+        />
         <Panel
           {...query}
           columns={columns}

--- a/src/components/ChartExperimental/ChartExperimentalHistogramStuff.jsx
+++ b/src/components/ChartExperimental/ChartExperimentalHistogramStuff.jsx
@@ -56,59 +56,32 @@ class ChartExperimentalHistogramStuff extends Component {
     let barData = this.makeBarData(histogramData)
     let maxValueX = findMaxObjKeyValue(barData, 'value') * 1.10
     let domainMaxY = findMaxObjKeyValue(barData, 'frequency') * 1.03
-    // let domainMaxY = maxValue + (maxValueY * 0.03)
-    const zerosDivStyle = {
-      width: w,
-      height: h
-    }
-    const innnerZerosDivStyle = {
-      width: w,
-      margin: '15% 5% 5% 5%',
-      padding: '10px',
-      position: 'relative',
-      color: fillColor
-    }
-    const zeroMsg = {
-      fontSize: '75%'
-    }
 
     return (
-      <Choose>
-        <When condition={dx === 0}>
-          <div className='zeros' style={zerosDivStyle}>
-            <div style={innnerZerosDivStyle}>
-              <p>No Chart to Display</p>
-              <p style={zeroMsg}> Column Only Contains 0 Values </p>
-            </div>
-          </div>
-        </When>
-        <Otherwise>
-          <BarChart
-            width={w}
-            height={h}
-            data={barData}
-            barGap={0}
-            margin={{ right: 10, left: 5 }}
-            barCategoryGap={0} >
-            <XAxis
-              dataKey={'value'}
-              type={'number'}
-              domain={[0, maxValueX]}
-              height={xAxisHeight}
-              label={<CustomXaxisLabel val={'Value of ' + colName} isGroupBy={false} numOfGroups={0} />} />
-            <YAxis
-              type={'number'}
-              width={yAxisWidth}
-              label={<CustomYaxisLabel val={'Frequency of Values'} h={h} chartType={'histogram'} />}
-              tickCount={yTickCnt}
-              tickFormatter={valTickFormater}
-              domain={[0, domainMaxY]} />
-            <CartesianGrid  stroke='#eee' strokeDasharray='3 3' vertical={false} />
-            <Tooltip content={<HistogramTooltip dx={dx} />} />
-            <Bar dataKey='frequency' fill={fillColor} />
-          </BarChart>
-        </Otherwise>
-      </Choose>
+      <BarChart
+        width={w}
+        height={h}
+        data={barData}
+        barGap={0}
+        margin={{ right: 10, left: 5 }}
+        barCategoryGap={0} >
+        <XAxis
+          dataKey={'value'}
+          type={'number'}
+          domain={[0, maxValueX]}
+          height={xAxisHeight}
+          label={<CustomXaxisLabel val={'Value of ' + colName} isGroupBy={false} numOfGroups={0} />} />
+        <YAxis
+          type={'number'}
+          width={yAxisWidth}
+          label={<CustomYaxisLabel val={'Frequency of Values'} h={h} chartType={'histogram'} />}
+          tickCount={yTickCnt}
+          tickFormatter={valTickFormater}
+          domain={[0, domainMaxY]} />
+        <CartesianGrid  stroke='#eee' strokeDasharray='3 3' vertical={false} />
+        <Tooltip content={<HistogramTooltip dx={dx} />} />
+        <Bar dataKey='frequency' fill={fillColor} />
+      </BarChart>
     )
   }
 }

--- a/src/components/DatasetFrontMatter/index.js
+++ b/src/components/DatasetFrontMatter/index.js
@@ -5,8 +5,6 @@ import moment from 'moment'
 // '2em'
 const DatasetFrontMatter = ({name, id, rowsUpdatedAt, apiDomain, dataId}) => {
   let timeAgo = moment(rowsUpdatedAt).fromNow()
-  //let dayUpdated = moment(rowsUpdatedAt).format('MM/DD/YYYY')
-  //let timeUpdated = moment(rowsUpdatedAt).format('hh:mm A')
   return (
     <div className='container'>
       <Row className={'dataSetTitle'} id='header'>

--- a/src/components/DatasetOverview/index.js
+++ b/src/components/DatasetOverview/index.js
@@ -193,7 +193,7 @@ class DatasetOverview extends Component {
           </Col>
         </Row>
         <Choose>
-          <When condition={relatedDatasets}>
+          <When condition={relatedDatasets && relatedDatasets.length !== 0}>
             <Row>
               <div className={'overview-description-breakline'}></div>
               <Col sm={12} className={'overview-publishing-details'}>
@@ -204,8 +204,6 @@ class DatasetOverview extends Component {
             </Row>
           </When>
         </Choose>
-
-
       </div>
 
     )

--- a/src/components/DatasetOverview/index.js
+++ b/src/components/DatasetOverview/index.js
@@ -81,7 +81,8 @@ class DatasetOverview extends Component {
 
 
   render () {
-    const { id, description, publishingDepartment, licenseLink, licenseName, notes, attachments, programLink, datasetFacts, colCounts, publishing_faqs, publishing_health, relatedDatasets, relatedDatasetCnt} = this.props.metadata
+    const { datasetFacts, colCounts, publishing_health, publishing_faqs } = this.props
+    const { id, description, publishingDepartment, licenseLink, licenseName, notes, attachments, programLink, relatedDatasets, relatedDatasetCnt} = this.props.metadata
     // let numberFormat = format(',')
     // let dayUpdated = moment(rowsUpdatedAt).format('MM/DD/YYYY')
     // let timeUpdated = moment(rowsUpdatedAt).format('hh:mm A')

--- a/src/components/DatasetOverview/index.js
+++ b/src/components/DatasetOverview/index.js
@@ -2,9 +2,9 @@ import './@DatasetOverview.css'
 
 import React, { Component } from 'react'
 import { Row, Col, OverlayTrigger, Popover } from 'react-bootstrap'
-// import { format } from 'd3'
-// import moment from 'moment'
 import RelatedDatasetTable from '../RelatedDatasetTable'
+import { setDocumentTitle } from '../../helpers'
+
 
 class DatasetOverview extends Component {
 
@@ -81,12 +81,8 @@ class DatasetOverview extends Component {
 
 
   render () {
-    const { datasetFacts, colCounts, publishing_health, publishing_faqs } = this.props
+    const { datasetFacts, colCounts, publishing_health, publishing_faqs, name } = this.props
     const { id, description, publishingDepartment, licenseLink, licenseName, notes, attachments, programLink, relatedDatasets, relatedDatasetCnt} = this.props.metadata
-    // let numberFormat = format(',')
-    // let dayUpdated = moment(rowsUpdatedAt).format('MM/DD/YYYY')
-    // let timeUpdated = moment(rowsUpdatedAt).format('hh:mm A')
-    // let overviewContent = null
     let attachmentList = this.renderAttachmentsList( attachments, id)
     let datasetFactsTbl =  this.makeDatasetFactsTable(datasetFacts, 'overview-dataset-facts-td', 'overview-dataset-facts-td')
     let datasetFieldCntTbl = this.makeDatasetFactsTable(colCounts, 'overview-dataset-facts-td',  'overview-dataset-cnts-td-value')
@@ -94,6 +90,10 @@ class DatasetOverview extends Component {
     let publishingFaqItems =  publishingHealthSpan.concat(this.renderPublishingInfo( publishing_faqs ) )
 
     let descPara = description ? description.split('\n\n').map((paragraph) => <p>{paragraph}</p>) : null
+
+    if(name) {
+      setDocumentTitle(name + ' | Overview')
+    }
 
       if (this.props.metadata) {
       // assemble related documents

--- a/src/components/DatasetOverview/index.js
+++ b/src/components/DatasetOverview/index.js
@@ -14,7 +14,7 @@ class DatasetOverview extends Component {
       attachmentList = attachments.map((att, idx, array) => {
       return (
         <li className={'overview-attachment-list'} key={idx}>
-          <a href={'https://data.sfgov.org/api/views/' + id + '/files/' + att.assetId + '?download=true&filename=' + att.filename}>
+          <a href={att.url}>
             {att.name}
           </a>
         </li>)

--- a/src/components/DatasetOverview/index.js
+++ b/src/components/DatasetOverview/index.js
@@ -93,6 +93,8 @@ class DatasetOverview extends Component {
     let publishingHealthSpan = [this.renderPublishingHealthSpan(publishing_health)]
     let publishingFaqItems =  publishingHealthSpan.concat(this.renderPublishingInfo( publishing_faqs ) )
 
+    let descPara = description ? description.split('\n\n').map((paragraph) => <p>{paragraph}</p>) : null
+
       if (this.props.metadata) {
       // assemble related documents
       let documents = []
@@ -109,28 +111,16 @@ class DatasetOverview extends Component {
           )
       }
 
-      // join tags with comma
-      //if (tags) {
-      //  tagList = (
-      //     <div>
-      //      <h3 className={'text-muted'}>Tags</h3>
-      //      <p>{tags}</p>
-      //    </div>
-      //    )
-      // }
-
     }
     return (
       <div className={'container overview'}>
         <div className={'overview-description'}>
-          <div>
-            {description}
-          </div>
+          {descPara}
           <Choose>
             <When condition={notes}>
-              <div className={'overview-description-notes'}>
+              <p>
                 {notes}
-              </div>
+              </p>
             </When>
           </Choose>
           <Choose>

--- a/src/components/DefaultListGroupItem/index.js
+++ b/src/components/DefaultListGroupItem/index.js
@@ -5,7 +5,7 @@ import './@DefaultListGroupItem.css'
 
 class DefaultListGroupItem extends Component {
   render () {
-    let {itemProps, onClick, buttonOverlay} = this.props
+    let {itemProps, onClick, buttonOverlay, key} = this.props
     let popOverPlacement = itemProps.hoverSide ? itemProps.hoverSide : 'left'
     let handleOnClick = typeof onClick === 'function'
       ? () => onClick(itemProps.fxnParams)
@@ -14,7 +14,9 @@ class DefaultListGroupItem extends Component {
       <Choose>
         <When condition={buttonOverlay}>
           <OverlayTrigger key={itemProps.value} trigger={['hover', 'focus']} placement={popOverPlacement} overlay={buttonOverlay}>
-            <ListGroupItem className={itemProps.className}
+            <ListGroupItem 
+              key={key}
+              className={itemProps.className}
               onClick={handleOnClick}>
               {itemProps.label}
               <Choose>
@@ -26,7 +28,9 @@ class DefaultListGroupItem extends Component {
           </OverlayTrigger>
         </When>
         <Otherwise>
-          <ListGroupItem className={itemProps.className}
+          <ListGroupItem 
+            key={key}
+            className={itemProps.className}
             onClick={handleOnClick}>
             {itemProps.label}
             <Choose>

--- a/src/components/FieldButton/index.js
+++ b/src/components/FieldButton/index.js
@@ -18,24 +18,26 @@ class FieldButton extends Component {
     }
     itemProps.className = setClassNamesListItem(itemProps, 'type', optionalClassNames)
     itemProps.otherComponents = itemProps.isSelected ? checked : null
-    itemProps.hoverSide =  hoverSide
+    itemProps.hoverSide = hoverSide
     return itemProps
   }
 
   render () {
-    let {itemProps, onClick, hoverSide} = this.props
+    let {itemProps, onClick, hoverSide, key} = this.props
     itemProps = this.setItemProps(itemProps, hoverSide)
     const FieldDefinition = <Popover id={'option-' + itemProps.value} title='Definition'>{itemProps.description || 'No definition available.'}</Popover>
     return (
       <Choose>
         <When condition={itemProps.isSelected}>
           <DefaultListGroupItem
+            key={key}
             itemProps={itemProps}
             buttonOverlay={FieldDefinition}
             onClick={onClick.bind(this, null)} />
         </When>
         <Otherwise>
           <DefaultListGroupItem
+            key={key}
             onClick={onClick.bind(this, itemProps.value)}
             itemProps={itemProps}
             buttonOverlay={FieldDefinition}   />

--- a/src/components/FieldSelector/index.js
+++ b/src/components/FieldSelector/index.js
@@ -17,6 +17,7 @@ const FieldSelector = ({title, types, onSelectListItem, hideshowVal, showCols, s
       <DefaultListGroup
         itemComponent={FieldButtonComponent}
         items={selectedField}
+        popOverPlacement={popOverPlacement}
         onSelectListItem={onSelectColumn} />
       : null}
       {selectedField.length === 0 || showCols !== 'show' || typeof showCols === 'undefined' ?

--- a/src/components/FieldSelector/index.js
+++ b/src/components/FieldSelector/index.js
@@ -10,39 +10,37 @@ import FieldButtonComponent from '../FieldButton'
 
 import './@FieldSelector.css'
 
-const FieldSelector = ({title, types, onSelectListItem, hideshowVal, showCols, setHideShow, popOverPlacement, selectableColumns, selectedField, onSelectColumn, onFilterTypes, onFilterList}) => {
-  return (
-    <Panel className='FieldSelector__root' collapsible defaultExpanded bsStyle='primary' header={<h4>{title} <span className='glyphicon collapse-icon' aria-hidden></span></h4>}>
-      {selectedField.length > 0 ?
+const FieldSelector = ({title, types, onSelectListItem, showCols, setHideShow, popOverPlacement, selectableColumns, selectedField, onSelectColumn, onFilterTypes, onFilterList}) => (
+  <Panel className='FieldSelector__root' collapsible defaultExpanded bsStyle='primary' header={<h4>{title} <span className='glyphicon collapse-icon' aria-hidden></span></h4>}>
+    {selectedField.length > 0 ?
+    <DefaultListGroup
+      itemComponent={FieldButtonComponent}
+      items={selectedField}
+      popOverPlacement={popOverPlacement}
+      onSelectListItem={onSelectColumn} />
+    : null}
+    {selectedField.length === 0 || showCols ?
+    (<div className={'FieldSelector__field-types-search-wrapper'}>
+      <h5>Filter field list by type</h5>
       <DefaultListGroup
-        itemComponent={FieldButtonComponent}
-        items={selectedField}
-        popOverPlacement={popOverPlacement}
-        onSelectListItem={onSelectColumn} />
-      : null}
-      {selectedField.length === 0 || showCols !== 'show' || typeof showCols === 'undefined' ?
-      (<div className={'FieldSelector__field-types-search-wrapper'}>
-        <h5>Filter field list by type</h5>
+        itemComponent={TypeButtonComponent}
+        className={'default-list-group'}
+        items={types}
+        onSelectListItem={onFilterTypes} />
+      <div className={'FieldSelector__field-search'}>
+        <FilterListInput onFilter={onFilterList} />
         <DefaultListGroup
-          itemComponent={TypeButtonComponent}
-          className={'default-list-group'}
-          items={types}
-          onSelectListItem={onFilterTypes} />
-        <div className={'FieldSelector__field-search'}>
-          <FilterListInput onFilter={onFilterList} />
-          <DefaultListGroup
-            itemComponent={FieldButtonComponent}
-            items={selectableColumns}
-            popOverPlacement={popOverPlacement}
-            onSelectListItem={onSelectColumn} />
-        </div>
-      </div>)
-      : null }
-      {selectedField.length > 0 ?
-      <HideShowButton itemProps={{'value': hideshowVal, 'isSelected': showCols}} onClick={setHideShow} showCols={showCols} />
-      : null }
-    </Panel>
-  )
-}
+          itemComponent={FieldButtonComponent}
+          items={selectableColumns}
+          popOverPlacement={popOverPlacement}
+          onSelectListItem={onSelectColumn} />
+      </div>
+    </div>)
+    : null }
+    {selectedField.length > 0 ?
+    <HideShowButton itemProps={{'value': selectableColumns ? selectableColumns.length + 1 : 0, 'isSelected': showCols}} onClick={setHideShow} showCols={showCols} />
+    : null }
+  </Panel>
+)
 
 export default FieldSelector

--- a/src/components/FieldTypeButton/index.js
+++ b/src/components/FieldTypeButton/index.js
@@ -18,10 +18,11 @@ class FieldTypeButton extends Component {
   }
 
   render () {
-    let {itemProps, onClick} = this.props
+    let {itemProps, onClick, key} = this.props
     itemProps = this.setItemProps(itemProps)
     return (
       <DefaultListGroupItem
+        key={key}
         itemProps={itemProps}
         onClick={onClick} />
     )

--- a/src/components/FilterChartOptions/@FilterOptions.scss
+++ b/src/components/FilterChartOptions/@FilterOptions.scss
@@ -1,5 +1,4 @@
 .filter {
-  z-index: 0;
   margin-bottom: 1.25em;
 }
 
@@ -17,10 +16,10 @@
   border: none;
 }
 
-.FilterChartOptions__select {
+.FilterChartOptions__filter-options .Select {
   z-index: 10;
 }
 
-.FilterChartOptions__root .Select {
-  z-index: 9;
+.FilterChartOptions__select {
+  z-index: 11;
 }

--- a/src/components/FilterChartOptions/index.js
+++ b/src/components/FilterChartOptions/index.js
@@ -101,7 +101,7 @@ class FilterOptions extends Component {
 
       return filterOption
     })
-    return filterOptions
+    return (<div className='FilterChartOptions__filter-options'>{filterOptions}</div>)
   }
 
   render () {

--- a/src/components/HideShowButton/index.js
+++ b/src/components/HideShowButton/index.js
@@ -2,39 +2,33 @@ import './@HideShowButton.css'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import DefaultListGroupItem from '../DefaultListGroupItem'
-// import {setClassNamesShowHide} from '../../helpers'
+
 class HideShowButton extends Component {
+  constructor(props) {
+    super(props)
+
+    this.setItemProps = this.setItemProps.bind(this)
+  }
 
   setItemProps (itemProps) {
+    let updatedProps = {...itemProps}
     const hideAll = (<span className='hide-show-icon glyphicon glyphicon-menu-up' aria-hidden='true' />)
     const showAll = (<span className='hide-show-icon glyphicon glyphicon-menu-down' aria-hidden='true' />)
     const showAllText = 'Show All '
     const hideAllText = 'Hide All '
-    // const classNameObj = {'base': 'show-hide-button', 'isSelected': 'field-type-button-is-selected', 'notSelected': 'field-type-button-selected'}
-    // itemProps.className = setClassNamesShowHide(itemProps, classNameObj)
-    itemProps.otherComponents = itemProps.isSelected ? hideAll : showAll
-    itemProps.label = itemProps.isSelected ? hideAllText : showAllText + ' (' + itemProps.value + ')'
-    itemProps.actfxnParams = itemProps.isSelected ? hideAllText : showAllText
-    itemProps.className = 'show-hide-button'
-    itemProps.actionFxnParams = itemProps.label
-    return itemProps
+    updatedProps.otherComponents = updatedProps.isSelected ? hideAll : showAll
+    updatedProps.label = updatedProps.isSelected ? hideAllText : showAllText + ' (' + updatedProps.value + ')'
+    updatedProps.actfxnParams = updatedProps.isSelected ? hideAllText : showAllText
+    updatedProps.className = 'show-hide-button'
+    updatedProps.actionFxnParams = updatedProps.label
+    return updatedProps
   }
 
   render () {
     let {itemProps, onClick, showCols} = this.props
-    if (showCols === 'hide') {
-      showCols = 'show'
-      itemProps.isSelected = true
-    } else if (showCols === 'show') {
-      showCols = 'hide'
-      itemProps.isSelected = false
-    } else {
-      showCols = 'show'
-      itemProps.isSelected = false
-    }
-    itemProps = this.setItemProps(itemProps)
+    let updatedProps = this.setItemProps(itemProps)
     return (
-      <DefaultListGroupItem itemProps={itemProps} onClick={onClick.bind(this, showCols)} />
+      <DefaultListGroupItem itemProps={updatedProps} onClick={onClick.bind(this, !showCols)} />
     )
   }
 }

--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -3,9 +3,11 @@ import './@HomePage.css'
 import React, { Component } from 'react'
 import AutoSuggestSearch from '../../containers/AutoSuggestSearch'
 import { Link } from 'react-router'
+import { setDocumentTitle } from '../../helpers'
 
 class HomePage extends Component {
   render () {
+    setDocumentTitle(false)
     return (
       <div id='main-container'>
         <section id='jumbo-search' className={'jumbotron jumbotron-default homepage'}>

--- a/src/components/Loading/@Loading.scss
+++ b/src/components/Loading/@Loading.scss
@@ -1,9 +1,11 @@
-.Loading-wrapper {
+.Loading__root {
   width:100%;
+  position: static;
+}
+
+.Loading__root--chart {
   min-height: 520px;
-  border: 2px dashed;
   position: relative;
-  border-color: #BDBDBD;
 }
 
 .Loading-indicator {
@@ -13,17 +15,17 @@
   left: 0;
   bottom: 0;
   right: 0;
-  padding-top: 15%;
+  padding-top: 10%;
   z-index: 2;
-  background: rgba(255, 255, 255, .7)
 }
 
-.Loading-wrapper.centered {
+.Loading__root--chart .Loading-indicator {
+  background: rgba(255, 255, 255, .7);
+}
+
+.centered .Loading-indicator {
   text-align: center;
   border: none;
-}
-
-.Loading-wrapper.centered .Loading-indicator {
 }
 
 

--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -42,7 +42,7 @@ class Loading extends Component {
     let { isFetching, hideChildrenWhileLoading, wraps } = this.props
     let { show } = this.state
     let type = this.props.type ? this.props.type : ''
-    let rootClass = wraps ? 'Loading__root' + '--' + wraps : 'Loading__root'
+    let rootClass = wraps ? 'Loading__root--' + wraps : 'Loading__root'
     let showChildren = !hideChildrenWhileLoading || (hideChildrenWhileLoading && !isFetching)
     let classNames = `${rootClass} ${type}`
     return (

--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -39,15 +39,17 @@ class Loading extends Component {
   }
 
   render () {
-    // let { isFetching } = this.props
+    let { isFetching, hideChildrenWhileLoading, wraps } = this.props
     let { show } = this.state
     let type = this.props.type ? this.props.type : ''
-    let classNames = `Loading-wrapper ${type}`
+    let rootClass = wraps ? 'Loading__root' + '--' + wraps : 'Loading__root'
+    let showChildren = !hideChildrenWhileLoading || (hideChildrenWhileLoading && !isFetching)
+    let classNames = `${rootClass} ${type}`
     return (
       <div className={classNames}>
         <IconLoading show={show} />
         <div>
-          {this.props.children}
+          {showChildren ? this.props.children : null}
         </div>
       </div>
     )

--- a/src/components/Messages/@Messages.scss
+++ b/src/components/Messages/@Messages.scss
@@ -1,0 +1,4 @@
+.Messages__message {
+    margin-left: 72px;
+    margin-right: 35px;
+}

--- a/src/components/Messages/index.js
+++ b/src/components/Messages/index.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Alert } from 'react-bootstrap'
+import './@Messages.css'
 
-const Message = ({title, type, message}) => (
+const Message = ({title, type, message, style}) => (
   type
-  ? <Alert bsStyle='danger'>
+  ? <Alert bsStyle={style} className={'Messages__message'}>
     <h4>{title}</h4>
     <p>{message}</p>
   </Alert> : false
@@ -13,12 +14,12 @@ const Message = ({title, type, message}) => (
 class Messages extends Component {
   render () {
     let { messages } = this.props
-    let title = messages.server ? 'Server Error' : 'Application Error'
     return (
-      <div className='Messages-wrapper'>
-        <Message title={title} type={messages.type} message={messages.message} />
-        {(messages.type !== 'error' && this.props.children)
-          ? this.props.children : false }
+      <div className='Messages__root'>
+        <Message title={messages.title} type={messages.type} style={messages.style} message={messages.message} />
+        { messages.showChildren !== false
+          ? this.props.children 
+          : null }
       </div>
     )
   }

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -58,7 +58,7 @@ class DynamicCell extends Component {
     let content
     if (format === 'location' && data[rowIndex][field]) {
       content = data[rowIndex][field].coordinates[1] + ', ' + data[rowIndex][field].coordinates[0]
-    } else if (format === 'boolean') {
+    } else if (type === 'boolean') {
       content = data[rowIndex][field] ? 'Yes' : 'No'
     } else if (format === 'calendar_date' && data[rowIndex][field]) {
       content = moment(data[rowIndex][field]).format('MM/DD/YYYY')

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -6,6 +6,7 @@ import {Table, Column, Cell} from 'fixed-data-table'
 import moment from 'moment'
 import Dimensions from 'react-dimensions'
 import { format as formatD3 } from 'd3'
+import { setDocumentTitle } from '../../helpers'
 
 var SortTypes = {
   ASC: 'asc',
@@ -93,8 +94,12 @@ class DataTable extends Component {
   }
 
   render () {
-    let { columns, rowCount, table } = this.props
+    let { columns, rowCount, table, name } = this.props
     let tableContainer = null
+
+    if(name) {
+      setDocumentTitle(name + ' | Table Preview')
+    }
 
     if (table && table.tableData && table.tableData.length > 0) {
       let perPage = 1000

--- a/src/containers/@containers.scss
+++ b/src/containers/@containers.scss
@@ -60,6 +60,16 @@
   background-color: #ddd;
 }
 
+.AutoSuggestSearch__root {
+  position: relative;
+}
+
+.AutoSuggestSearch__no-results {
+  padding: 10px 20px;
+  font-style: italic;
+  color: #adadad;
+}
+
 .AutoSuggestSearch__footer {
   border-top: thin solid #d3d3d3;
   padding: 10px 20px;

--- a/src/containers/AutoSuggestSearch.js
+++ b/src/containers/AutoSuggestSearch.js
@@ -9,7 +9,7 @@ import {connectSearchBox} from 'react-instantsearch/connectors'
 import Autosuggest from 'react-autosuggest'
 import { browserHistory } from 'react-router'
 import slugify from 'underscore.string/slugify'
-import { updateSearch } from '../actions'
+import { updateSearch, selectSearchRecord } from '../actions'
 
 class AutoSuggestSearch extends Component {
   render () {
@@ -23,7 +23,11 @@ class AutoSuggestSearch extends Component {
         <div>
           <Configure hitsPerPage={5} />
           <VirtualSearchBox />
-          <ConnectedAutoComplete attributes={[]} className={this.props.className} onSearchStateChange={this.props.updateSearch} />
+          <ConnectedAutoComplete 
+            attributes={[]} 
+            className={this.props.className} 
+            onSearchStateChange={this.props.updateSearch} 
+            onSelectRecord={this.props.onSelectRecord} />
         </div>
       </InstantSearch>
     )
@@ -102,9 +106,10 @@ class AutoComplete extends Component {
           onChange: () => {}
         }}
         onSuggestionSelected={(event, {suggestion, suggestionIndex}) => {
-          let link = '/' + slugify(suggestion.category) + '/' + slugify(suggestion.name) + '/' + suggestion.systemID
+          let link = '/' + slugify(suggestion.category) + '/' + slugify(suggestion.name) + '/' + suggestion.objectID
           this.refs.autosuggest.input.value = ''
           this.props.refine({query: '', hideSuggestions: true})
+          this.props.onSelectRecord(suggestion)
           browserHistory.push(link)
         }}
         renderSuggestionsContainer={renderSuggestionsContainer}
@@ -129,7 +134,8 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    updateSearch: (searchState) => dispatch(updateSearch(searchState))
+    updateSearch: (searchState) => dispatch(updateSearch(searchState)),
+    onSelectRecord: (record) => dispatch(selectSearchRecord(record))
   }
 }
 

--- a/src/containers/Catalog.js
+++ b/src/containers/Catalog.js
@@ -6,6 +6,7 @@ import isEqual from 'lodash/isEqual'
 import {withRouter} from 'react-router'
 import qs from 'qs'
 import { updateSearch, selectSearchRecord } from '../actions'
+import { setDocumentTitle } from '../helpers'
 
 class Catalog extends Component {
 
@@ -40,6 +41,7 @@ class Catalog extends Component {
   createURL = state => `${this.props.location.pathname}?${qs.stringify(state)}`;
 
   render () {
+    setDocumentTitle('Data Catalog')
     return (
       <InstantSearch
         appId='N6IVMSP2S4'

--- a/src/containers/Catalog.js
+++ b/src/containers/Catalog.js
@@ -1,25 +1,25 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { InstantSearch } from 'react-instantsearch/dom'
+import { InstantSearch, Configure } from 'react-instantsearch/dom'
 import Search from '../components/Catalog'
 import isEqual from 'lodash/isEqual'
 import {withRouter} from 'react-router'
 import qs from 'qs'
-import { updateSearch, clearSearch } from '../actions'
+import { updateSearch, selectSearchRecord } from '../actions'
 
 class Catalog extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { searchState: { ...qs.parse(props.router.location.query) } };
+    this.state = { searchState: qs.parse(this.props.router.location.query) }
   }
 
   componentWillReceiveProps() {
-    this.setState({ searchState: qs.parse(this.props.router.location.query) });
+    this.setState({ searchState: qs.parse(this.props.router.location.query) })
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return !isEqual(this.state.searchState, nextState.searchState);
+    return !isEqual(this.state.searchState, nextState.searchState)
   }
 
   onSearchStateChange(nextSearchState) {
@@ -49,7 +49,8 @@ class Catalog extends Component {
         onSearchStateChange={this.onSearchStateChange.bind(this)}
         createURL={state => this.createURL.bind(this)}
       >
-        <Search clearSearch={this.props.clearSearch} />
+        <Configure hitsPerPage={10} page={1} />
+        <Search onClickRecord={this.props.onClickRecord} />
       </InstantSearch>
     )
   }
@@ -65,7 +66,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     onSearchStateChange: (searchState) => dispatch(updateSearch(searchState)),
-    clearSearch: () => dispatch(clearSearch())
+    onClickRecord: (record) => dispatch(selectSearchRecord(record))
   }
 }
 

--- a/src/containers/ChartFieldSelector.js
+++ b/src/containers/ChartFieldSelector.js
@@ -9,14 +9,13 @@ const mapStateToProps = (state, ownProps) => ({
   selectableColumns: getSelectableColumns(state),
   selectedField: getSelectedField(state),
   title: getSelectedField(state).length > 0 ? 'Selected field' : 'Select a field',
-  hideshowVal: getSelectableColumns(state).length,
   showCols: state.columnProps.showCols
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   onFilterTypes: item => dispatch(filterColumnList('typeFilters', item, 'columnProps')),
   onFilterList: item => dispatch(filterColumnList('fieldNameFilter', item, 'columnProps')),
-  onSelectColumn: (key) => dispatch(selectColumn(key)),
+  onSelectColumn: key => dispatch(selectColumn(key)),
   setHideShow: showCols => dispatch(setHideShow(showCols, 'columnProps')),
   resetState: resetState => dispatch(resetState('columnProps'))
 })

--- a/src/containers/Dataset.js
+++ b/src/containers/Dataset.js
@@ -43,8 +43,7 @@ class Dataset extends Component {
 
   render () {
     const { rowsUpdatedAt, name, id, dataId, hasGeo, isFetching, children, ...other } = this.props
-    const childrenWithHeight = React.Children.map(children, 
-      (child) => React.cloneElement(child, this.state))
+    const childrenWithDatasetProps = React.Children.map(children, (child) => React.cloneElement(child, {...this.state, name}))
 
     return (
       <Loading isFetching={isFetching} hideChildrenWhileLoading={true} type='centered'>
@@ -60,7 +59,7 @@ class Dataset extends Component {
           <DatasetNav id={id} dataId={dataId} hasGeo={hasGeo} {...other} />
         </section>
         <section id={'DatasetChildren'} style={{width: '100%', minHeight: '100px'}}>
-          {childrenWithHeight}
+          {childrenWithDatasetProps}
         </section>
       </Loading>
     )

--- a/src/containers/Dataset.js
+++ b/src/containers/Dataset.js
@@ -47,7 +47,7 @@ class Dataset extends Component {
       (child) => React.cloneElement(child, this.state))
 
     return (
-      <Loading isFetching={true} hideChildrenWhileLoading={true} type='centered'>
+      <Loading isFetching={isFetching} hideChildrenWhileLoading={true} type='centered'>
         <section id={'DatasetFrontmatter'}>
           <DatasetFrontMatter 
             apiDomain={API_DOMAIN} 

--- a/src/containers/Dataset.js
+++ b/src/containers/Dataset.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { loadMetadata, loadColumnProps, loadTable } from '../actions'
 import DatasetFrontMatter from '../components/DatasetFrontMatter'
 import DatasetNav from '../components/DatasetNav'
+import Loading from '../components/Loading'
 import { API_DOMAIN } from '../constants/AppConstants'
 
 class Dataset extends Component {
@@ -28,7 +29,8 @@ class Dataset extends Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
-    let height = document.getElementById('DatasetFrontmatter').clientHeight
+    // TODO: may be more foolproof to get this by ref
+    let height = document.getElementById('DatasetFrontmatter') ? document.getElementById('DatasetFrontmatter').clientHeight : prevState.frontMatterHeight
     let viewportHeight = window.innerHeight
     if (prevState.frontMatterHeight !== height) {
       this.setState({ 
@@ -40,29 +42,40 @@ class Dataset extends Component {
   }
 
   render () {
-    const { metadata, children, ...other } = this.props
+    const { rowsUpdatedAt, name, id, dataId, hasGeo, isFetching, children, ...other } = this.props
     const childrenWithHeight = React.Children.map(children, 
       (child) => React.cloneElement(child, this.state))
+
     return (
-      <div>
+      <Loading isFetching={true} hideChildrenWhileLoading={true} type='centered'>
         <section id={'DatasetFrontmatter'}>
-          <DatasetFrontMatter apiDomain={API_DOMAIN} {...metadata} />
+          <DatasetFrontMatter 
+            apiDomain={API_DOMAIN} 
+            name={name} 
+            id={id}
+            dataId={dataId}
+            rowsUpdatedAt={rowsUpdatedAt} />
         </section>
         <section id={'DatasetNav'}>
-          <DatasetNav id={metadata.id} dataId={metadata.dataId} hasGeo={metadata.hasGeo} {...other} />
+          <DatasetNav id={id} dataId={dataId} hasGeo={hasGeo} {...other} />
         </section>
         <section id={'DatasetChildren'} style={{width: '100%', minHeight: '100px'}}>
           {childrenWithHeight}
         </section>
-      </div>
+      </Loading>
     )
   }
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { metadata } = state
+  const { rowsUpdatedAt, name, id, dataId, hasGeo, isFetching } = state.metadata
   return {
-    metadata
+    name,
+    id,
+    dataId,
+    hasGeo,
+    isFetching,
+    rowsUpdatedAt
   }
 }
 

--- a/src/containers/DatasetOverview.js
+++ b/src/containers/DatasetOverview.js
@@ -5,17 +5,13 @@ import { loadRelatedDatasets } from '../actions'
 
 const mapStateToProps = (state, ownProps) => {
   const { metadata } = state
-  metadata.datasetFacts = makeDatasetFactDictFxn(state)
-  metadata.colCounts = makeColTypesCntFxn(state)
-  metadata.publishingFacts = makePublishingFactsFxn(state)
-  metadata.publishing_health = calculatePublishingHealthFxn(state)
-  metadata.publishing_faqs = makePublishingFactsFxn(state)
-  if (state.routing.locationBeforeTransitions.pathname) {
-    let route = state.routing.locationBeforeTransitions.pathname.split("/")
-    metadata.fbf = route[route.length-1]
-  }
   return {
-    metadata
+    metadata,
+    datasetFacts: makeDatasetFactDictFxn(state),
+    colCounts: makeColTypesCntFxn(state),
+    publishingFacts: makePublishingFactsFxn(state),
+    publishing_health: calculatePublishingHealthFxn(state),
+    publishing_faqs: makePublishingFactsFxn(state)
   }
 }
 

--- a/src/containers/FieldDefinitions.js
+++ b/src/containers/FieldDefinitions.js
@@ -6,11 +6,16 @@ import { filterColumnList, selectField, setHideShow, sortColumnList} from '../ac
 import { getUniqueColumnTypesDetails, getSelectableColumnsDetails, getSelectedFieldDef, getSelectedFieldDetails, getFieldProfileInfo} from '../reducers'
 import FieldProfile from '../components/FieldProfile'
 import FieldDefFieldSelector from './FieldDefFieldSelector'
+import { setDocumentTitle } from '../helpers'
 
-const ColumnDetails = ({topOffset, list, filters, onFilter, sort, onSort, fieldTypeItems, selectableColumns, onSelectColumn, selectedColumnDef, hideshowVal, selectedField, setHideShow, showCols, selectedProfileInfo, selectedCategories }) => {
+const ColumnDetails = ({name, topOffset, list, filters, onFilter, sort, onSort, fieldTypeItems, selectableColumns, onSelectColumn, selectedColumnDef, hideshowVal, selectedField, setHideShow, showCols, selectedProfileInfo, selectedCategories }) => {
   let absoluteTop = {
       top: (topOffset) + 'px'
     }
+  
+  if(name) {
+    setDocumentTitle(name + ' | Field Definitions')
+  }
   return (
   <Row className={'column-details-all-container'}>
     <Col sm={3} className={'field-details-panel-picker-container'} style={absoluteTop}>

--- a/src/containers/VizContainer.js
+++ b/src/containers/VizContainer.js
@@ -174,6 +174,7 @@ const mapStateToProps = (state, ownProps) => {
   const encodedJSON = encodeURIComponent(JSON.stringify(queryState))
   const embedLink = BASE_HREF + '/#/e/' + id + '?q=' + encodedJSON
   const embedCode = '<iframe src="' + embedLink + '" width="100%" height="400" allowfullscreen frameborder="0"></iframe>'
+  const exclude = query.filters ? Object.keys(query.filters) : []
   return {
     props: {
       name: ownProps.name,
@@ -200,7 +201,7 @@ const mapStateToProps = (state, ownProps) => {
       summableColumns: getSummableColumns(state),
       groupableColumns: getGroupableColumns(state),
       selectableColumns: getSelectableColumns(state),
-      filterableColumns: getSelectableColumns(state, false, true)
+      filterableColumns: getSelectableColumns(state, false, true, exclude)
     }
   }
 }

--- a/src/containers/VizContainer.js
+++ b/src/containers/VizContainer.js
@@ -112,7 +112,7 @@ class VizContainer extends Component {
                     </Col>
                   </Row>
                 </div>
-                <Loading isFetching={props.isFetching} type='centered'>
+                <Loading isFetching={props.isFetching} type='centered' wraps='chart'>
                   <Choose>
                     <When condition={props.chartData}>
                       <Choose>

--- a/src/containers/VizContainer.js
+++ b/src/containers/VizContainer.js
@@ -79,7 +79,6 @@ class VizContainer extends Component {
           </Accordion>
         </Col>
         <Col className='VizContainer__stage' style={absoluteTop}>
-          <Messages messages={props.messages}>
             <ConditionalOnSelect selectedColumn={props.selectedColumn} displayBlank={<BlankChart />}>
               <div className='Chart__root'>
                 <div className='Chart__header'>
@@ -119,35 +118,27 @@ class VizContainer extends Component {
                   </Row>
                 </div>
                 <Loading isFetching={props.isFetching} type='centered' wraps='chart'>
-                  <Choose>
-                    <When condition={props.chartData}>
-                      <Choose>
-                        <When condition={props.chartData.length > 0}>
-                          <ChartExperimentalCanvas
-                            chartData={props.chartData || []}
-                            chartType={props.chartType}
-                            dateBy={props.dateBy}
-                            rollupBy={props.rollupBy}
-                            groupKeys={props.groupKeys}
-                            filters={props.filters}
-                            rowLabel={props.rowLabel}
-                            selectedColumnDef={props.selectedColumnDef}
-                            groupBy={props.groupBy}
-                            sumBy={props.sumBy}
-                            isFetching={props.isFetching} />
-                        </When>
-                        <When condition={props.chartData.length === 0 && props.filters}>
-                          <div className={'filterNone'}>
-                              Based on the filters you've applied, your query retrieved no results. Remove some of the filters and try again.
-                          </div>
-                        </When>
-                      </Choose>
-                    </When>
-                  </Choose>
+                  <Messages messages={props.messages}>
+                    <Choose>
+                      <When condition={props.chartData}>
+                        <ChartExperimentalCanvas
+                          chartData={props.chartData || []}
+                          chartType={props.chartType}
+                          dateBy={props.dateBy}
+                          rollupBy={props.rollupBy}
+                          groupKeys={props.groupKeys}
+                          filters={props.filters}
+                          rowLabel={props.rowLabel}
+                          selectedColumnDef={props.selectedColumnDef}
+                          groupBy={props.groupBy}
+                          sumBy={props.sumBy}
+                          isFetching={props.isFetching} />
+                      </When>
+                    </Choose>
+                  </Messages>
                 </Loading>
               </div>
             </ConditionalOnSelect>
-          </Messages>
         </Col>
       </Row>
     )

--- a/src/containers/VizContainer.js
+++ b/src/containers/VizContainer.js
@@ -19,6 +19,7 @@ import OtherDataToggle from '../components/Query/OtherDataToggle'
 import ChartTypePicker from '../components/ChartTypePicker'
 import Loading from '../components/Loading'
 import Messages from '../components/Messages'
+import { setDocumentTitle } from '../helpers'
 import './@containers.css'
 
 import ChartFieldSelector from '../containers/ChartFieldSelector'
@@ -43,6 +44,11 @@ class VizContainer extends Component {
     let absoluteTop = {
       top: (props.topOffset) + 'px'
     }
+
+    if (props.name) {
+      setDocumentTitle(props.name + ' | Charts')
+    }
+
     return (
       <Row>
         <ModalShare />
@@ -179,6 +185,7 @@ const mapStateToProps = (state, ownProps) => {
   const embedCode = '<iframe src="' + embedLink + '" width="100%" height="400" allowfullscreen frameborder="0"></iframe>'
   return {
     props: {
+      name: ownProps.name,
       frontMatterHeight: ownProps.frontMatterHeight,
       topOffset: ownProps.topOffset,
       id,

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -14,6 +14,7 @@ H.transformOthers = require('./transformOthers.js')
 H.sumObj = require('./sumObj.js')
 H.sortObj = require('./sortObj.js')
 H.setClassNamesListItem = require('./setClassNamesListItem.js')
+H.setDocumentTitle = require('./setDocumentTitle.js')
 // Implement chaining
 H.prototype = {
   value: function value () {

--- a/src/helpers/setDocumentTitle.js
+++ b/src/helpers/setDocumentTitle.js
@@ -1,0 +1,7 @@
+module.exports = function setDocumentTitle(title) {
+  if (title) {
+    document.title = 'DataSF Open Data Explorer | ' + title
+  } else {
+    document.title = 'DataSF Open Data Explorer'
+  }
+}

--- a/src/middleware/metadatasf.js
+++ b/src/middleware/metadatasf.js
@@ -41,6 +41,7 @@ function transformMetadata (json) {
   metadata.rowLabel = metadata.rowLabel || 'Row'
   metadata.keywords = metadata.keywords !== null ? metadata.keywords.split(',') : []
   metadata.isFetching = false
+  metadata.fromSearch = false
   return metadata
 }
 

--- a/src/middleware/metadatasf.js
+++ b/src/middleware/metadatasf.js
@@ -25,7 +25,6 @@ function endpointColumns (id) {
   return API_ROOT + `fielddetails/${id}`
 }
 function endpointRelatedDatasets (id) {
-  //console.log(API_ROOT + `relateddatasets/${id}`)
   return API_ROOT + `relateddatasets/${id}`
 }
 
@@ -38,8 +37,10 @@ export const TransformsSF = {
 
 function transformMetadata (json) {
   // Set default rowLabel
-  json[0].rowLabel = json[0].rowLabel || 'Record'
   let metadata = json[0]
+  metadata.rowLabel = metadata.rowLabel || 'Row'
+  metadata.keywords = metadata.keywords !== null ? metadata.keywords.split(',') : []
+  metadata.isFetching = false
   return metadata
 }
 

--- a/src/middleware/socrata.js
+++ b/src/middleware/socrata.js
@@ -106,8 +106,8 @@ function constructQuery (state) {
       let filter = filters[key]
 
       if (filter.options && column.type === 'date') {
-        let start = filter.options.min.format('YYYY-MM-DD')
-        let end = filter.options.max.format('YYYY-MM-DD')
+        let start = moment(filter.options.min).format('YYYY-MM-DDTHH:mm:ss.SSS')
+        let end = moment(filter.options.max).format('YYYY-MM-DDTHH:mm:ss.SSS')
         query.where(key + '>="' + start + '" and ' + key + '<="' + end + '"')
       } else if (column.categories && filter.options && filter.options.selected) {
         let enclose = '"'

--- a/src/reducers/columnsReducer.js
+++ b/src/reducers/columnsReducer.js
@@ -103,7 +103,7 @@ export const getSelectedField = (state, selectedColumn) => {
   }).sort(sortColumns)
 }
 
-export const getSelectableColumns = (state, selectedColumn, all = false, ignoreTypeFilters = false) => {
+export const getSelectableColumns = (state, selectedColumn, all = false, ignoreTypeFilters = false, exclude = []) => {
   let { columns, typeFilters, fieldNameFilter } = state
   if (!columns) return []
   return Object.keys(columns).filter((col) => {
@@ -115,6 +115,9 @@ export const getSelectableColumns = (state, selectedColumn, all = false, ignoreT
       return false
     }
     if (fieldNameFilter && columns[col].name.toLowerCase().indexOf(fieldNameFilter.toLowerCase()) === -1) {
+      return false
+    }
+    if (exclude.indexOf(col) > -1) {
       return false
     }
     if (ignoreTypeFilters && selectable) {

--- a/src/reducers/columnsReducer.js
+++ b/src/reducers/columnsReducer.js
@@ -111,7 +111,7 @@ export const getSelectableColumns = (state, selectedColumn, all = false, ignoreT
     if (all) return true
 
     let selectable = isSelectable(columns, col)
-    if (state.showCols === 'hide' && col === selectedColumn) {
+    if (col === selectedColumn) {
       return false
     }
     if (fieldNameFilter && columns[col].name.toLowerCase().indexOf(fieldNameFilter.toLowerCase()) === -1) {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -51,8 +51,8 @@ export const getUniqueColumnTypes = (state, selectable) =>
 export const getGroupableColumns = state =>
   fromColumns.getGroupableColumns(state.columnProps, state.query.selectedColumn)
 
-export const getSelectableColumns = (state, all = false, ignoreTypeFilters = false) =>
-  fromColumns.getSelectableColumns(state.columnProps, state.query.selectedColumn, all, ignoreTypeFilters)
+export const getSelectableColumns = (state, all = false, ignoreTypeFilters = false, exclude = []) => 
+  fromColumns.getSelectableColumns(state.columnProps, state.query.selectedColumn, all, ignoreTypeFilters, exclude)
 
 export const getSummableColumns = state =>
   fromColumns.getSummableColumns(state.columnProps)

--- a/src/reducers/messagesReducer.js
+++ b/src/reducers/messagesReducer.js
@@ -1,28 +1,52 @@
 import * as ActionTypes from '../actions'
-import { updateObject } from './reducerUtilities'
+import { updateObject, createReducer } from './reducerUtilities'
 
 const initialState = {}
 
-function setMessage (state, action) {
+function setFailureMessage (state, action) {
+  let title = typeof action.status !== 'undefined' ? 'Server Error' : 'Application Error'
   return updateObject(state, {
     message: action.message,
     type: 'error',
-    server: typeof action.status !== 'undefined',
-    dismissable: false })
+    style: 'danger',
+    title: title,
+    dismissable: false,
+    showChildren: false })
+}
+
+function checkForMessages (state, action) {
+  let allZeroes = action.response.query && (action.response.query.originalData.length === 1 && action.response.query.originalData[0].label === '0')
+  let noData = action.response.query && action.response.query.originalData.length === 0
+  let message = noData ? 'The query returned no data.' : 'Column only contains values equal to 0.'
+  message += ' Please try a different selection of columns and/or filters.'
+  let title = noData ? 'Query returned no data' : 'No chart data'
+  if (noData || allZeroes) {
+    return updateObject(state, {
+      message,
+      type: 'info',
+      style: 'info',
+      title,
+      dismissable: false,
+      showChildren: false
+    })
+  } 
+  
+  if (action.response.query && action.response.query.originalData.length > 0) {
+    return initialState
+  }
+
+  return state
 }
 
 function clearAllMessages (state, action) {
   return initialState
 }
 
-export const messagesReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case ActionTypes.QS_FAILURE:
-    case ActionTypes.COLPROPS_FAILURE:
-    case ActionTypes.DATA_FAILURE: return setMessage(state, action)
-    case ActionTypes.METADATA_REQUEST:
-    case ActionTypes.SELECT_COLUMN: return clearAllMessages(state, action)
-    default:
-      return state
-  }
-}
+export const messagesReducer = createReducer(initialState, {
+  [ActionTypes.QS_FAILURE]: setFailureMessage,
+  [ActionTypes.COLPROPS_FAILURE]: setFailureMessage,
+  [ActionTypes.DATA_FAILURE]: setFailureMessage,
+  [ActionTypes.METADATA_REQUEST]: clearAllMessages,
+  [ActionTypes.SELECT_COLUMN]: clearAllMessages,
+  [ActionTypes.DATA_SUCCESS]: checkForMessages
+})

--- a/src/reducers/metadataReducer.js
+++ b/src/reducers/metadataReducer.js
@@ -139,6 +139,7 @@ function resetState (state, action) {
 function preloadMetadata (state, action) {
   let data = action.payload
   data.fromSearch = true
+  data.isFetching = false
   data.relatedDatasetCnt = 0
   data.relatedDatasets = []
   data.attachments = null

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -12,12 +12,12 @@ function updateSearch (state, action) {
   return updateObject(state, action.payload)
 }
 
-function clearSearch (state, action) {
+function selectSearchRecord (state, action) {
   return initialState
 }
 
 // create reducer
 export const searchReducer = createReducer(initialState, {
   [ActionTypes.UPDATE_SEARCH]: updateSearch,
-  [ActionTypes.CLEAR_SEARCH]: clearSearch
+  [ActionTypes.SELECT_SEARCH_RECORD]: selectSearchRecord
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6044,9 +6044,9 @@ react-inspector@^1.1.0:
     babel-runtime "^6.9.2"
     is-dom "^1.0.5"
 
-react-instantsearch@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-4.0.0.tgz#9fa009ceac65c4842ec9aa4a41178b10a69d95e6"
+react-instantsearch@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-4.0.10.tgz#472ca4f8a7a471db095ee5135f1c20eced6f248f"
   dependencies:
     algoliasearch "^3.21.1"
     algoliasearch-helper "2.19.0"


### PR DESCRIPTION
## What does it do

Addresses the following:

1. #378 - fixes broken file attachment links 7f2a133
2. #362 - fixes issue where selecting a catalog facet would jump the page to the search bar 3db88c8
3 #362 - address several minor cosmetic issues on the catalog, add row counts to results
4. #227 #354 - loads search record into metadata state and introduces loading lifecycle on dataset (when coming directly) a24a218 030bd9b 7b3e99b 22cf723 a5b2724
5. #376 - removes related datasets component when 0 related datasets b30484f
6. #380 - removes `Promise.all()` from `fetchRelatedDatasets` in `actions\index.js` to address an issue where this call was blocking other async calls
7. #366 - fixes an issue where boolean fields weren't being output in the table 732149a
8. #336 - added an informative message to the autosuggest search when the terms return no results, removed the pagination when there were no extra pages, did not add an additional message to the catalog as the implementation was causing some performance issues d0a1708
9. #381 - broke description text with \n\n into `<p>` 64d5358
10. #364 - added a function to change the title of the page, implemented on all the primary route components 5f5f6b0
11. #371 - updated the messages for no chart data and only zeroes to use the messages reducer and component, bringing these into consistency with messaging in other parts of the app cbb82f9
12. #382 - removes chosen filters from filter pick list 5384e8a
13. #375 - fixes issue where sharing a chart with time filters would crash the chart, addresses related issues where the hideShow button wouldn't be initially instantiated when viewing a shared URL 83fac92

## Things to know

cc/ @j9recurses 

- Refactors `DatasetOverview.js` and `DatasetOverview\index.js` a little, props were mutating the application state a24a218 030bd9b 
- Refactors actions and components related to the HideShow button to address an issue with loading from a URL 83fac92

## Screenshots

### Catalog and search

<img width="1679" alt="screen shot 2017-08-07 at 9 53 26 am" src="https://user-images.githubusercontent.com/534176/29036928-5cf5c712-7b56-11e7-98fb-a01ee762ff36.png">

<img width="1680" alt="screen shot 2017-08-07 at 9 53 43 am" src="https://user-images.githubusercontent.com/534176/29036940-6209b510-7b56-11e7-8dbf-fa4ef5c9f709.png">

### Added `<p>` to replace \n\n

<img width="1143" alt="screen shot 2017-08-07 at 9 55 17 am" src="https://user-images.githubusercontent.com/534176/29036995-9a5e5d44-7b56-11e7-981e-8ff2e881fa44.png">





